### PR TITLE
Support Reply-To header for Mailer

### DIFF
--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -98,3 +98,5 @@ mailer:
   # Any addressses that should be CC'd on sent emails.  If set, this can be a
   # single address or a list.
   cc_addrs: null
+  # An optional address for the "Reply-To" header of sent emails.
+  reply_to: null


### PR DESCRIPTION
This adds support for the "Reply-To" email header field in the Mailer class, and adds a stub to the default config file to document this feature.  This fixes #2.