### PR TITLE
Email alert on failure

### DIFF
--- a/test_umbra/test_common.py
+++ b/test_umbra/test_common.py
@@ -11,6 +11,7 @@ import re
 import csv
 from zipfile import ZipFile
 import hashlib
+import sys
 
 import umbra
 from umbra import (illumina,  util)

--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -106,3 +106,6 @@ mailer:
   cc_addrs: null
   # An optional address for the "Reply-To" header of sent emails.
   reply_to: null
+  # Any addresses that should receive email alerts of processing failures (in
+  # addition to cc_addrs).
+  to_addrs_on_error: null

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -415,7 +415,20 @@ class IlluminaProcessor:
             try:
                 proj.process()
             except Exception as e:
-                self.logger.error("Failed project: %s\n" % proj.name)
+                subject = "Failed project: %s\n" % proj.name
+                self.logger.error(subject)
                 self.logger.error(traceback.format_exc())
+                config_mail = self.config.get("mailer", {})
+                contacts = config_mail.get("to_addrs_on_error", [])
+                body = "Project processing failed for \"%s\"" % proj.work_dir
+                body += " with the following message:\n"
+                body += "\n\n"
+                body += traceback.format_exc()
+                kwargs = {
+                        "to_addrs": contacts,
+                        "subject": subject,
+                        "msg_body": body
+                        }
+                self.mailer(**kwargs)
             self._queue_jobs.task_done()
             self._queue_completion.put(proj)


### PR DESCRIPTION
Updates IlluminaProcessor to use the configured mailer, if any, to send an alert email if processing fails.  This fixes #3.