### PR TITLE
Allow multithreading for processing tasks

### DIFF
--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -15,6 +15,9 @@ readonly: false
 # How many worker threads should be run in parallel?  This sets an upper limit
 # on how many projects will be processed at a time.
 nthreads: 1
+# How many threads should each of the above workers use, at maximum, during
+# processing?
+nthreads_per_project: 1
 # Should run directories newer than a certain age be skipped in a given refresh
 # cycle?  This can avoid spurious warnings for partially-written run data.
 # Configure as a number of seconds from the present time.

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -42,6 +42,7 @@ class IlluminaProcessor:
         self.path_proc = self._init_path(paths.get("processed", "processed"))
         self.path_pack = self._init_path(paths.get("packaged", "packaged"))
         self.nthreads = config.get("nthreads", 1)
+        self.nthreads_per_project = config.get("nthreads_per_project", 1)
         self.readonly = config.get("readonly")
         self._init_data()
         self._init_job_queue()
@@ -389,14 +390,16 @@ class IlluminaProcessor:
         Any projects with previously-created metadata on disk will be marked
         inactive and not processed."""
         self.logger.debug("proccesing new alignment: %s" % al.path)
-        projs = project.ProjectData.from_alignment(al,
-                self.path_exp,
-                self.path_status,
-                self.path_proc,
-                self.path_pack,
-                self.uploader,
-                self.mailer,
-                self.readonly)
+        projs = project.ProjectData.from_alignment(
+                alignment = al,
+                path_exp = self.path_exp,
+                dp_align = self.path_status,
+                dp_proc = self.path_proc,
+                dp_pack = self.path_pack,
+                uploader = self.uploader,
+                mailer = self.mailer,
+                nthreads = self.nthreads_per_project,
+                readonly = self.readonly)
         for proj in projs:
             suffix = ""
             if proj.readonly:

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -78,6 +78,7 @@ class ProjectData:
     def from_alignment(alignment, path_exp, dp_align, dp_proc, dp_pack,
             uploader,
             mailer,
+            nthreads=1,
             readonly=False):
         """Make dict of ProjectData objects from alignment/experiment table."""
         # Row by row, build up a dict for each unique project.  Even though
@@ -108,14 +109,17 @@ class ProjectData:
             for name in names:
                 proj_file = slugify(name) + ".yml"
                 fp = Path(dp_align) / run_id / al_idx / proj_file
-                proj = ProjectData(name, fp,
-                        dp_proc,
-                        dp_pack,
-                        alignment,
-                        experiment_info,
-                        uploader,
-                        mailer,
-                        exp_path,
+                proj = ProjectData(
+                        name = name,
+                        path = fp,
+                        dp_proc = dp_proc,
+                        dp_pack = dp_pack,
+                        alignment = alignment,
+                        exp_info_full = experiment_info,
+                        uploader = uploader,
+                        mailer = mailer,
+                        exp_path = exp_path,
+                        nthreads = nthreads,
                         readonly = readonly)
                 proj.sample_paths = sample_paths
                 projects.add(proj)
@@ -125,14 +129,14 @@ class ProjectData:
             uploader,
             mailer,
             exp_path=None,
-            threads=1,
+            nthreads=1,
             readonly=False):
 
         self.logger = logging.getLogger(__name__)
         self.name = name
         self.alignment = alignment
         self.path = path # YAML metadata path
-        self.threads = threads # max threads to give tasks
+        self.nthreads = nthreads # max threads to give tasks
         self.uploader = uploader # callback to upload zip file
         self.mailer = mailer # callback to send email
         # TODO phred score should really be a property of the Illumina
@@ -387,7 +391,7 @@ class ProjectData:
             return(fp_out)
         args = ["spades.py", "--12", fq_in,
                 "-o", dir_out,
-                "-t", self.threads,
+                "-t", self.nthreads,
                 "--phred-offset", self.phred_offset]
         args = [str(x) for x in args]
         # spades tends to throw nonzero exit codes with short files, empty


### PR DESCRIPTION
This exposes `ProjectData`'s support for a threads attribute to `IlluminaProcessor` and the configuration file.  Fixes #12.