### PR TITLE
Actually compress files when making zip archives

### DIFF
--- a/test_umbra/test_common.py
+++ b/test_umbra/test_common.py
@@ -9,7 +9,6 @@ from distutils.file_util import copy_file
 from pathlib import Path
 import re
 import csv
-from zipfile import ZipFile
 import hashlib
 import sys
 

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -12,6 +12,7 @@ that.
 
 from .test_common import *
 import gzip
+import zipfile
 import warnings
 import yaml
 import threading
@@ -267,9 +268,14 @@ class TestProjectDataOneTask(TestBase):
         
         This will also check for the YAML metadata file in the expected hidden
         location."""
-        # In the zipfile we should also find those same files.
-        with ZipFile(self.proj.path_pack, "r") as z:
+        with zipfile.ZipFile(self.proj.path_pack, "r") as z:
             info = z.infolist()
+            # Check compression status.  It should actually be compressed, and
+            # with the expected method.
+            item = info[0]
+            self.assertTrue(item.compress_size < item.file_size)
+            self.assertEqual(item.compress_type, zipfile.ZIP_DEFLATED)
+            # Check that the expected files are all present in the zipfile.
             files = [i.filename for i in info]
             for f in files_exp:
                 p = Path(self.proj.work_dir) / self.run.run_id / f

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -2,7 +2,7 @@ from .util import *
 from . import experiment
 import yaml
 import traceback
-from zipfile import ZipFile
+import zipfile
 import subprocess
 from Bio import SeqIO
 import warnings
@@ -469,7 +469,9 @@ class ProjectData:
     def zip(self):
         """Create zipfile of processing directory and metadata."""
         mkparent(self.path_pack)
-        with ZipFile(self.path_pack, "x") as z:
+        # By default ZipFile will not actually compress!  We need to specify a
+        # compression method explicitly for that.
+        with zipfile.ZipFile(self.path_pack, "x", zipfile.ZIP_DEFLATED) as z:
             # Archive everything in the processing directory
             for root, dirs, files in os.walk(self.path_proc):
                 for fn in files:


### PR DESCRIPTION
This explicitly specifies a compression method when calling `zipfile.ZipFile` in `ProjectData.zip`.  Fixes #16.