### PR TITLE
Use min_age setting for alignment directories

### DIFF
--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -20,7 +20,9 @@ nthreads: 1
 nthreads_per_project: 1
 # Should run directories newer than a certain age be skipped in a given refresh
 # cycle?  This can avoid spurious warnings for partially-written run data.
-# Configure as a number of seconds from the present time.
+# Configure as a number of seconds from the present time.  This will be
+# separately applied to the Alignment directories within each run directory as
+# well.
 min_age: null
 # How about run directories older than a certain age?
 max_age: null

--- a/umbra/illumina/run.py
+++ b/umbra/illumina/run.py
@@ -91,9 +91,19 @@ class Run:
         self.alignments += al
 
     def _alignment_setup(self, path):
-        # Try loading an alignment directory, but just throw a warning and
-        # return None if it doesn't look like an Alignment.  This should handle
-        # not-yet-complete Alignment directories on disk.
+        # Try loading an alignment directory, but skip if the alignment
+        # directory looks too new on disk (according to min_alignment_dir_age)
+        # or just throw a warning and return None if it doesn't look like an
+        # Alignment.  This should handle not-yet-complete Alignment directories
+        # on disk while avoiding spurious warnings.
+        min_age = self.min_alignment_dir_age
+        time_change = path.stat().st_ctime
+        time_now = time.time()
+        if min_age is not None and (time_now - time_change < min_age):
+            msg = "skipping alignment; timestamp too new:.../%s/.../%s" % (
+                    self.path.name, path.name)
+            self.logger.debug(msg)
+            return(None)
         try:
             al = Alignment(path, self, self.alignment_callback)
         except ValueError as e:

--- a/umbra/illumina/util.py
+++ b/umbra/illumina/util.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree
 import csv
 import re
 import datetime
+import time
 from pathlib import Path
 
 ADAPTERS = {

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -319,7 +319,8 @@ class IlluminaProcessor:
             self.logger.debug("loading new run:.../%s" % run_dir.name)
             run = illumina.run.Run(run_dir,
                     strict = True,
-                    alignment_callback = self._proc_new_alignment)
+                    alignment_callback = self._proc_new_alignment,
+                    min_alignment_dir_age = min_age)
         except Exception as e:
             # ValueError for unrecognized or mismatched directories
             if type(e) is ValueError:


### PR DESCRIPTION
This passes along the min_age setting already applied to run directories to alignment subdirectories as well. 
Fixes #20.