### PR TITLE
Include Project working directory in report and YAML files

### DIFF
--- a/test_umbra/test_processor.py
+++ b/test_umbra/test_processor.py
@@ -40,7 +40,7 @@ class TestIlluminaProcessor(TestBase):
         # MD5 sum of the report CSV text, minus the RunPath column.
         # This is after fulling loading the default data, but before starting
         # processing.
-        self.report_md5 = "40c9bf2b0f99159c9cc061a58ca7bb91"
+        self.report_md5 = "a6288d49f223ad85b564069701bc8b6f"
         # Temporary path to use for a report
         self.report_path = Path(self.tmpdir.name) / "report.csv"
         # The header entries we expect to see in the CSV report text.
@@ -51,6 +51,7 @@ class TestIlluminaProcessor(TestBase):
                 "Experiment",
                 "AlignComplete",
                 "Project",
+                "WorkDir",
                 "Status",
                 "NSamples",
                 "NFiles",
@@ -243,7 +244,7 @@ class TestIlluminaProcessorDuplicateRun(TestIlluminaProcessor):
         self.warn_msg += "run-files-custom-name / "
         self.warn_msg += "180102_M00000_0000_000000000-XXXXX"
         # There's an extra line in the report due to the duplicated run
-        self.report_md5 = "ccf4d07a070b7f1ce5bf65e587721652"
+        self.report_md5 = "6d3a716cc86a08f382e29474847f018b"
 
     def test_load(self):
         # One run dir in particular is named oddly and is a duplicate of the
@@ -290,7 +291,7 @@ class TestIlluminaProcessorReadonly(TestIlluminaProcessor):
     def setUpVars(self):
         super().setUpVars()
         # All projects inactive in this case
-        self.report_md5 = "493730e3e0e7698f92bc5230fad2a25b"
+        self.report_md5 = "513fb89c2d3341352ad34e791eae5fdf"
 
     def test_refresh(self):
         """Basic scenario for refresh(): a new run directory appears.
@@ -338,7 +339,7 @@ class TestIlluminaProcessorReportConfig(TestIlluminaProcessor):
         # watch_and_process will automatically call start(), and this wrapper
         # will wait, so we'll get a completed ProjectData for one case.
         # Need an MD5 for a slightly different report in that case
-        self.report_md5 = "703bbe9ffe7a3270a14a8a3718a4e07b"
+        self.report_md5 = "c815570da24ce8e556d8e50b454a8eb1"
         self._watch_and_process_maybe_warning()
         # If a report was configured, it should exist
         with open(self.report_path) as f:

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -119,6 +119,8 @@ class TestProjectData(TestBase):
         md_str["status"] = "complete"
         md_str["task_output"] = {}
         md_se["task_output"] = {}
+        md_se["work_dir"] = "2018-01-01-Something_Else-Someone-Jesse"
+        md_str["work_dir"] = "2018-01-01-STR-Jesse"
 
         fq = self.path_runs/"180101_M00000_0000_000000000-XXXXX/Data/Intensities/BaseCalls"
         fps = {

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -21,6 +21,7 @@ class IlluminaProcessor:
                 "AlignComplete", # Is the alignment complete?
                 # Project attributes
                 "Project",       # Name of project from extra metadata
+                "WorkDir",       # Project working directory name
                 "Status",        # Project data processing status
                 "NSamples",      # Num samples in project data
                 "NFiles",        # Num files in project data
@@ -227,6 +228,7 @@ class IlluminaProcessor:
                         for proj in projs:
                             entry_proj = dict(entry_al)
                             entry_proj["Project"] = proj.name
+                            entry_proj["WorkDir"] = proj.work_dir
                             entry_proj["Status"] = proj.status
                             entry_proj["NSamples"] = len(proj.experiment_info["sample_names"])
                             entry_proj["NFiles"] = sum([len(x) for x in proj.sample_paths.values()])

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -160,12 +160,29 @@ class ProjectData:
             self._metadata["experiment_info"]["name"] = self.alignment.experiment
         if self.alignment.run:
             self._metadata["run_info"]["path"] = str(self.alignment.run.path)
+        self._metadata["work_dir"] = self._init_work_dir_name()
 
         self.path_proc = Path(dp_proc) / self.work_dir
         self.path_pack = Path(dp_pack) / (self.work_dir + ".zip")
         if not self.readonly:
             self.save_metadata()
         self.logger.info("ProjectData initialized: %s" % self.work_dir)
+
+    def _init_work_dir_name(self):
+        txt_date = datestamp(self.alignment.run.rta_complete["Date"])
+        txt_proj = slugify(self.name)
+        # first names of contacts given
+        who = self.experiment_info["contacts"]
+        who = [txt.split(" ")[0] for txt in who.keys()]
+        who = "-".join(who)
+        txt_name = slugify(who)
+        fields = [txt_date, txt_proj, txt_name]
+        fields = [f for f in fields if f]
+        dirname = "-".join(fields)
+        # TODO better exception here
+        if not dirname:
+            raise Exception("empty work_dir")
+        return(dirname)
 
     @property
     def status(self):
@@ -188,20 +205,7 @@ class ProjectData:
     @property
     def work_dir(self):
         """Short name for working directory, without path"""
-        txt_date = datestamp(self.alignment.run.rta_complete["Date"])
-        txt_proj = slugify(self.name)
-        # first names of contacts given
-        who = self.experiment_info["contacts"]
-        who = [txt.split(" ")[0] for txt in who.keys()]
-        who = "-".join(who)
-        txt_name = slugify(who)
-        fields = [txt_date, txt_proj, txt_name]
-        fields = [f for f in fields if f]
-        dirname = "-".join(fields)
-        # TODO better exception here
-        if not dirname:
-            raise Exception("empty work_dir")
-        return(dirname)
+        return(self._metadata["work_dir"])
 
     @property
     def sample_paths(self):


### PR DESCRIPTION
This modifies IlluminaProcessor to include a column in the CSV reports for the working directory name for each project found, and modifies ProjectData to keep this attribute stored in the metadata dictionary kept synced with its YAML equivalent on disk.  This should make cross-referencing runs and projects easier and fix #15.