### PR TITLE
Handle sample name mismatches between metadata.csv and SampleSheet.csv

### DIFF
--- a/umbra/illumina/alignment.py
+++ b/umbra/illumina/alignment.py
@@ -83,7 +83,11 @@ class Alignment:
 
     @property
     def sample_numbers(self):
-        """Ordered list of all sample numbers (indexed from one)."""
+        """Ordered list of all sample numbers (indexed from one).
+        
+        Note that the sample number (the integer after the "S" in filenames) is
+        not the same thing as the Sample_ID values given in a sample sheet,
+        though they may happen to have the same values in a run."""
         num_range = range(len(self.sample_sheet["Data"]))
         nums = [i+1 for i in num_range]
         return(nums)

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -417,7 +417,7 @@ class IlluminaProcessor:
                 readonly = self.readonly)
         for proj in projs:
             suffix = ""
-            if proj.readonly:
+            if proj.readonly or proj.status == project.ProjectData.FAILED:
                 grp = "inactive"
                 self.projects[grp].add(proj)
                 if proj.status != project.ProjectData.COMPLETE:


### PR DESCRIPTION
This checks for, logs, and handles the possible mismatch of sample names between the experiment metadata spreadsheet and sample sheet.  Fixes #28.