### PR TITLE
Support configurable parent directories for task outputs

### DIFF
--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -892,17 +892,17 @@ class TestProjectDataPathConfig(TestProjectDataOneTask):
 
     def setUpProj(self):
         self.tasks_config  = {
-                "log_path": "RunDiagnostics/logs",
-                "implicit_tasks_path": "RunDiagnostics/ImplicitTasks"
-                }
+            "log_path": "RunDiagnostics/logs",
+            "implicit_tasks_path": "RunDiagnostics/ImplicitTasks"
+            }
         projs = ProjectData.from_alignment(self.alignment,
-                self.path_exp,
-                self.path_status,
-                self.path_proc,
-                self.path_pack,
-                self.uploader,
-                self.mailer,
-                config = self.tasks_config)
+            self.path_exp,
+            self.path_status,
+            self.path_proc,
+            self.path_pack,
+            self.uploader,
+            self.mailer,
+            config = self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
@@ -914,8 +914,8 @@ class TestProjectDataPathConfig(TestProjectDataOneTask):
         self.assertTrue(metadata_path.exists())
         trim_path_default = self.proj.path_proc / "trimmed"
         trim_path = (self.proj.path_proc /
-                self.tasks_config["implicit_tasks_path"] /
-                "trimmed")
+            self.tasks_config["implicit_tasks_path"] /
+            "trimmed")
         merge_path = self.proj.path_proc / "PairedReads"
         # Trim path should have changed.  Merge path should have been left the
         # same.

--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -42,6 +42,18 @@ paths:
   packaged: "packaged"
 
 ##############################################################################
+# Task configuration options. The Box and Mailer options are handled
+# separately; see sections below.
+# Paths here are relative to a particular project's processing directory.
+task_options:
+  # Subdirectory to use for implicitly-required (not explicitly requested for
+  # the project) task output directories.  By default these are stored
+  # side-by-side on the top level with the rest of the per-task directories.
+  implicit_tasks_path: ""
+  # Subdirectory to use for per-task log files.
+  log_path: "logs"
+
+##############################################################################
 # Options for the report displayed during the "report" action.
 report:
   max_width: 60


### PR DESCRIPTION
This adds a `task_options` section to the configuration and passes it into each ProjectData object, supplying custom parent paths for log files and implicitly-required tasks, relative to a particular processing directory.  (This does not add support for custom directory names per task.)  Fixes #32 and #33.