### PR TITLE
Keep Geneious dependency outputs at top level

### DIFF
--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -588,11 +588,6 @@ class TestProjectDataGeneious(TestProjectDataOneTask):
     marker appears and then will continue processing.
     """
 
-    #def setUp(self):
-    #    self.task = "geneious"
-    #    self.tasks_run = ["trim", "merge", "assemble", "geneious"] + DEFAULT_TASKS
-    #    super().setUp()
-
     def setUpVars(self):
         self.task = "geneious"
         self.tasks_run = ["trim", "merge", "assemble", "geneious"] + DEFAULT_TASKS
@@ -616,15 +611,6 @@ class TestProjectDataGeneious(TestProjectDataOneTask):
 
     def finish_manual(self):
         (self.proj.path_proc / "Geneious").mkdir()
-
-    #def test_process(self):
-    #    # It should finish as long as it finds the Geneious directory
-    #    t = threading.Timer(1, self.finish_manual)
-    #    t.start()
-    #    super().test_process()
-    #    self.assertTrue((self.proj.path_proc / "PairedReads").exists())
-    #    self.assertTrue((self.proj.path_proc / "ContigsGeneious").exists())
-    #    self.assertTrue((self.proj.path_proc / "CombinedGeneious").exists())
 
     def test_process(self):
         # It should finish as long as it finds the Geneious directory

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -581,6 +581,62 @@ class TestProjectDataManual(TestProjectDataOneTask):
         super().test_process()
 
 
+class TestProjectDataGeneious(TestProjectDataOneTask):
+    """ Test for single-task "geneious".
+
+    Test that a ProjectData with a geneious task specified will wait until a
+    marker appears and then will continue processing.
+    """
+
+    #def setUp(self):
+    #    self.task = "geneious"
+    #    self.tasks_run = ["trim", "merge", "assemble", "geneious"] + DEFAULT_TASKS
+    #    super().setUp()
+
+    def setUpVars(self):
+        self.task = "geneious"
+        self.tasks_run = ["trim", "merge", "assemble", "geneious"] + DEFAULT_TASKS
+        super().setUpVars()
+
+    def setUpProj(self):
+        self.tasks_config  = {
+            "implicit_tasks_path": "RunDiagnostics/ImplicitTasks"
+            }
+        projs = ProjectData.from_alignment(self.alignment,
+            self.path_exp,
+            self.path_status,
+            self.path_proc,
+            self.path_pack,
+            self.uploader,
+            self.mailer,
+            config = self.tasks_config)
+        for proj in projs:
+            if proj.name == self.project_name:
+                self.proj = proj
+
+    def finish_manual(self):
+        (self.proj.path_proc / "Geneious").mkdir()
+
+    #def test_process(self):
+    #    # It should finish as long as it finds the Geneious directory
+    #    t = threading.Timer(1, self.finish_manual)
+    #    t.start()
+    #    super().test_process()
+    #    self.assertTrue((self.proj.path_proc / "PairedReads").exists())
+    #    self.assertTrue((self.proj.path_proc / "ContigsGeneious").exists())
+    #    self.assertTrue((self.proj.path_proc / "CombinedGeneious").exists())
+
+    def test_process(self):
+        # It should finish as long as it finds the Geneious directory
+        t = threading.Timer(1, self.finish_manual)
+        t.start()
+        super().test_process()
+        # Despite the config, these directories should now be at the top level.
+        self.assertTrue((self.proj.path_proc / "PairedReads").exists())
+        self.assertTrue((self.proj.path_proc / "ContigsGeneious").exists())
+        self.assertTrue((self.proj.path_proc / "CombinedGeneious").exists())
+
+
 class TestProjectDataMetadata(TestProjectDataOneTask):
     """ Test for single-task "metadata".
 

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -780,6 +780,16 @@ class ProjectData:
         # Wait for a "Geneious" subdirectory to appear in the processing
         # directory.
         elif task == ProjectData.TASK_GENEIOUS:
+            # Override the implicit task hiding for this specific case.  This
+            # is brittle but should work for the time being.
+            paths_move = [
+                self._task_dir_parent(self.TASK_MERGE)/"PairedReads",
+                self._task_dir_parent(self.TASK_ASSEMBLE)/"ContigsGeneious",
+                self._task_dir_parent(self.TASK_ASSEMBLE)/"CombinedGeneious"
+                ]
+            for p in paths_move:
+                if p.parent != self.path_proc:
+                    shutil.move(str(p), str(self.path_proc))
             while not (self.path_proc / "Geneious").exists():
                 time.sleep(1)
 


### PR DESCRIPTION
This pulls several directories back up to the top level alongside the Geneious directory, if the `implicit_tasks_path` config setting is in use.