### PR TITLE
Modularize tasks into separate classes

### DIFF
--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -604,7 +604,7 @@ class TestProjectDataGeneious(TestProjectDataOneTask):
             self.path_pack,
             self.uploader,
             self.mailer,
-            config = self.tasks_config)
+            conf = self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
@@ -976,7 +976,7 @@ class TestProjectDataPathConfig(TestProjectDataOneTask):
             self.path_pack,
             self.uploader,
             self.mailer,
-            config = self.tasks_config)
+            conf = self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
@@ -1024,7 +1024,7 @@ class TestProjectDataImplicitTasks(TestProjectDataOneTask):
             self.path_pack,
             self.uploader,
             self.mailer,
-            config = self.tasks_config)
+            conf = self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj

--- a/test_umbra/test_task.py
+++ b/test_umbra/test_task.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+"""
+Tests for Task objects (and classes!)
+
+Right now this mostly just tests the weird inheritance and other aspects of
+tasks, and test_project.py has more "live" testing.
+"""
+
+from umbra import task
+from .test_common import *
+
+class TestTaskModule(unittest.TestCase):
+    """Tests on the task module."""
+
+    def test_task_classes(self):
+        """Check the dict of task classes for the module.
+
+        The module should bring Task* clases from each task_* child module up
+        to the top level, and task_classes should present them in dictionary
+        form by name.
+        """
+        cls_dict = task.task_classes()
+        keys_expected = set((
+            "noop",
+            "fail",
+            "copy",
+            "trim",
+            "assemble",
+            "merge",
+            "manual",
+            "geneious",
+            "metadata",
+            "package",
+            "email",
+            "upload"))
+        self.assertEqual(set(cls_dict.keys()), keys_expected)
+
+
+class TestTaskClass(unittest.TestCase):
+    """Tests on the Task class itself."""
+
+    def setUp(self):
+        self.thing = task.Task
+
+    def test_name(self):
+        """Test that the name property is defined."""
+        self.assertEqual(self.thing.name, "task")
+
+    def test_source_path(self):
+        """Test that source_path is a Path pointing to the source code."""
+        self.assertEqual(self.thing.source_path, Path("__init__.py"))
+
+    def test_order(self):
+        """Test that the numeric order attribute is defined."""
+        self.assertEqual(self.thing.order, 100)
+
+    def test_dependencies(self):
+        """Test that the dependency list is defined."""
+        self.assertEqual(self.thing.dependencies, [])
+
+    def test_summary(self):
+        """Test the string summary method."""
+        summary_expected = [
+            "name: task",
+            "order: 100",
+            "dependencies: ",
+            "source_path: __init__.py"]
+        summary_expected = "\n".join(summary_expected)
+        self.assertEqual(self.thing.summary, summary_expected)
+
+    def test_sort(self):
+        """Test sorting on tasks and all related operators.
+
+        These should work on Tasks as instances or classes."""
+        class Task2(task.Task):
+            """Another Task class that should come later."""
+            order = 200
+        thing2 = Task2({}, None)
+        # < > <= >= for class and instance cases
+        self.assertTrue(self.thing < Task2)
+        self.assertFalse(self.thing > Task2)
+        self.assertTrue(self.thing <= Task2)
+        self.assertFalse(self.thing >= Task2)
+        self.assertTrue(self.thing < thing2)
+        self.assertFalse(self.thing > thing2)
+        self.assertTrue(self.thing <= thing2)
+        self.assertFalse(self.thing >= thing2)
+        ## If we make a jumbled list it'll sort properly
+        vec = [Task2, self.thing]
+        self.assertEqual(vec[::-1], sorted(vec))
+        vec = [thing2, self.thing]
+        self.assertEqual(vec[::-1], sorted(vec))
+
+
+class TestTask(TestTaskClass):
+    """Tests on any Task instance.
+
+    Everything that works on a Task class should work on a Task instance, and
+    more."""
+
+    def setUp(self):
+        self.thing = task.Task({}, None)
+
+    def test_run(self):
+        with self.assertRaises(NotImplementedError):
+            self.thing.run()

--- a/test_umbra/test_task.py
+++ b/test_umbra/test_task.py
@@ -2,12 +2,13 @@
 """
 Tests for Task objects (and classes!)
 
-Right now this mostly just tests the weird inheritance and other aspects of
-tasks, and test_project.py has more "live" testing.
+Right now this mostly just tests the weird Python inheritance and other aspects
+of tasks, and test_project.py has more "live" testing for actual task code.
 """
 
+import unittest
+from pathlib import Path
 from umbra import task
-from .test_common import *
 
 class TestTaskModule(unittest.TestCase):
     """Tests on the task module."""
@@ -72,6 +73,7 @@ class TestTaskClass(unittest.TestCase):
         """Test sorting on tasks and all related operators.
 
         These should work on Tasks as instances or classes."""
+        # pylint: disable=abstract-method
         class Task2(task.Task):
             """Another Task class that should come later."""
             order = 200
@@ -102,5 +104,6 @@ class TestTask(TestTaskClass):
         self.thing = task.Task({}, None)
 
     def test_run(self):
+        """Test that the run method is left unimplemented by default."""
         with self.assertRaises(NotImplementedError):
             self.thing.run()

--- a/umbra/__init__.py
+++ b/umbra/__init__.py
@@ -15,3 +15,6 @@ structures on disk.  The experiment module contains helper functions for
 matching the Experiment field from a sample sheet with a matching set of
 metadata on disk.
 """
+
+from . import config
+CONFIG = config.layer_configs([config.path_for_config()])

--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -52,6 +52,17 @@ task_options:
   implicit_tasks_path: ""
   # Subdirectory to use for per-task log files.
   log_path: "logs"
+  # These tasks will always be executed
+  task_defaults: ["metadata", "email"]
+  # These tasks will be executed if no tasks at all are specified
+  task_null: ["copy"]
+  # These are specific per-task options
+  tasks:
+    assemble:
+      # Min length of contigs to keep in filtered Geneious-ready form
+      contig_length_min: 255
+      # FASTQ quality score encoding offset
+      phred_offset: 33
 
 ##############################################################################
 # Options for the report displayed during the "report" action.

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -442,7 +442,7 @@ class IlluminaProcessor:
             mailer=self.mailer,
             nthreads=self.nthreads_per_project,
             readonly=self.readonly,
-            config=self.config.get("task_options", {}))
+            conf=self.config.get("task_options", {}))
         for proj in projs:
             suffix = ""
             if proj.readonly or proj.status == project.ProjectData.FAILED:

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -386,8 +386,8 @@ class ProjectData:
         tasks = []
         for taskname in tasknames:
             cls = tasks_all[taskname]
-            config = self.config["tasks"].get(taskname, {})
-            obj = cls(config, self)
+            task_config = self.config["tasks"].get(taskname, {})
+            obj = cls(task_config, self)
             tasks.append(obj)
         # Sort by the order attribute of each task.
         tasks = sorted(tasks)
@@ -422,4 +422,4 @@ class ProjectData:
         if not taskobj:
             # This should never happen (so it probably will).
             raise ProjectError("task \"%s\" not recognized" % taskname)
-        self._metadata["task_output"][taskname] = taskobj.run() or {}
+        self._metadata["task_output"][taskname] = taskobj.runwrapper() or {}

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -12,29 +12,18 @@ that may arise (e.g., attempting to process a readonly project, existing files
 in the processing output directory, unexpected input data formats, etc).
 """
 
-import shutil
 import traceback
-import zipfile
-import subprocess
-import csv
 import logging
-import re
-import time
 import sys
-import os
 import warnings
+import copy
 from pathlib import Path
-from distutils.dir_util import copy_tree
 import yaml
-from Bio import SeqIO
-from . import experiment, illumina
-from .util import touch, mkparent, slugify, datestamp
-# requires on PATH:
-#  * cutadapt
-#  * spades.py
-
-class ProjectError(Exception):
-    """Any sort of project-related exception."""
+from . import CONFIG
+from . import config
+from . import experiment
+from .util import ProjectError, mkparent, slugify, datestamp
+from . import task
 
 class ProjectData:
     """The data for a Run and Alignment specific to one project.
@@ -55,59 +44,10 @@ class ProjectData:
     FAILED        = "failed"
     STATUS = [NONE, PROCESSING, PACKAGE_READY, COMPLETE, FAILED]
 
-    # Recognized tasks:
-    TASK_NOOP     = "noop"     # do nothing
-    TASK_FAIL     = "fail"     # trigger a failure
-    TASK_COPY     = "copy"     # copy raw files
-    TASK_TRIM     = "trim"     # trim adapters
-    TASK_MERGE    = "merge"    # interleave trimmed R1/R2 reads
-    TASK_ASSEMBLE = "assemble" # contig assembly
-    TASK_MANUAL   = "manual"   # manual intervention step
-    TASK_GENEIOUS = "geneious" # special manual case
-    TASK_METADATA = "metadata" # copy metadata to working dir
-    TASK_PACKAGE  = "package"  # package in zip file
-    TASK_UPLOAD   = "upload"   # upload to Box
-    TASK_EMAIL    = "email"    # email contacts
-
-    # Adding an explicit order and dependencies.
-    TASKS = [
-        TASK_NOOP,
-        TASK_FAIL,
-        TASK_COPY,
-        TASK_TRIM,
-        TASK_MERGE,
-        TASK_ASSEMBLE,
-        TASK_MANUAL,
-        TASK_GENEIOUS,
-        TASK_METADATA,
-        TASK_PACKAGE,
-        TASK_UPLOAD,
-        TASK_EMAIL
-        ]
-
-    TASK_DEPS = {
-        TASK_EMAIL: [TASK_UPLOAD],
-        TASK_UPLOAD: [TASK_PACKAGE],
-        TASK_MERGE: [TASK_TRIM],
-        TASK_ASSEMBLE: [TASK_MERGE],
-        TASK_GENEIOUS: [TASK_ASSEMBLE]
-        }
-
-    # We'll always include these tasks:
-    TASK_DEFAULTS = [
-        TASK_METADATA,
-        TASK_EMAIL
-        ]
-
-    # If nothing else is given, this will be added:
-    TASK_NULL = [
-        TASK_COPY
-        ]
-
     @staticmethod
     def from_alignment(alignment, path_exp, dp_align, dp_proc, dp_pack,
                        uploader, mailer, nthreads=1, readonly=False,
-                       config=None):
+                       conf=None):
         """Make set of ProjectData objects from alignment/experiment table.
 
         This is called from IlluminaProcessor and so is protected from a set of
@@ -154,7 +94,7 @@ class ProjectData:
                     exp_path=exp_path,
                     nthreads=nthreads,
                     readonly=readonly,
-                    config=config)
+                    conf=conf)
                 try:
                     proj.sample_paths = sample_paths
                 except ProjectError:
@@ -171,7 +111,7 @@ class ProjectData:
     def __init__(
             self, name, path, dp_proc, dp_pack, alignment, exp_info_full,
             uploader, mailer, exp_path=None, nthreads=1, readonly=False,
-            config=None):
+            conf=None):
 
         self.logger = logging.getLogger(__name__)
         self.name = name
@@ -182,15 +122,8 @@ class ProjectData:
         self.uploader = uploader # callback to upload zip file
         self.mailer = mailer # callback to send email
         # general configuration including per-task options
-        self.config = config
-        if self.config is None:
-            self.config = {}
-        # TODO phred score should really be a property of the Illumina
-        # alignment data, since it depends on the software generating the
-        # fastqs.
-        self.phred_offset = 33 # FASTQ quality score encoding offset
-        self.contig_length_min = 255
-
+        self.config = copy.deepcopy(CONFIG["task_options"])
+        config.update_tree(self.config, conf or {})
         self._metadata = {"status": ProjectData.NONE}
         self.readonly = self.path.exists() or readonly
         self.load_metadata()
@@ -199,6 +132,7 @@ class ProjectData:
         self._metadata["experiment_info"]["path"] = str(exp_path or "")
         self._metadata["run_info"] = {}
         self._metadata["sample_paths"] = {}
+        self.tasks = self._setup_tasks()
         self._metadata["task_status"] = self._setup_task_status()
         self._metadata["task_output"] = {}
         if self.alignment:
@@ -334,9 +268,9 @@ class ProjectData:
         """Name of task currently running."""
         return self._metadata["task_status"]["current"]
 
-    def deps_completed(self, task):
+    def deps_completed(self, taskname):
         """ Are all dependencies of a given task already completed?"""
-        deps = ProjectData.TASK_DEPS.get(task, [])
+        deps = self.__deps_for(taskname)
         remaining = [d for d in deps if d not in self.tasks_completed]
         return not remaining
 
@@ -403,278 +337,6 @@ class ProjectData:
         with open(self.path, "w") as fout:
             fout.write(yaml.dump(self._metadata))
 
-    ###### Task-related methods
-
-    def copy_run(self):
-        """Copy the run directory into the processing directory."""
-        src = str(self.alignment.run.path)
-        dest = str(self._task_dir_parent(self.TASK_COPY) /
-                   self.alignment.run.run_id)
-        copy_tree(src, dest)
-
-    def _task_dir_parent(self, taskname):
-        """Give processing parent path for a given task.
-
-        This will take into account configuration settings for the project and
-        the specific task, if present.  If all defaults are set this will just
-        be the processing directory.
-        """
-        path_implicit = "."
-        if taskname not in self.experiment_info["tasks"]:
-            path_implicit = self.config.get("implicit_tasks_path", ".")
-        path = (self.path_proc / path_implicit).resolve()
-        return path
-
-    def task_path(self, readfile, taskname, subdir, suffix="", r1only=True):
-        """Give readfile-related path, following the originals' name."""
-        pat = "(.*_L[0-9]+_)R([12])(_001)\\.fastq\\.gz"
-        if r1only:
-            name = re.sub(pat, "\\1R\\3" + suffix, readfile.name)
-        else:
-            name = re.sub(pat, "\\1R\\2\\3" + suffix, readfile.name)
-        fastq_out = self._task_dir_parent(taskname) / subdir / name
-        mkparent(fastq_out)
-        return fastq_out
-
-    def _log_path(self, task):
-        # TODO set up sane handling of defaults, using the package's config
-        # file.
-        path = (self.path_proc /
-                self.config.get("log_path", "logs") /
-                ("log_" + str(task) + ".txt")).resolve()
-        mkparent(path)
-        return path
-
-    def trim(self):
-        """Trim adapters from raw fastq.gz files."""
-        # For each sample, separately process the one or more associated files.
-        with open(self._log_path("trim"), "w") as fout:
-            for samp in self.sample_paths.keys():
-                paths = self.sample_paths[samp]
-                if len(paths) > 2:
-                    raise ProjectError("trimming can't handle >2 files per sample")
-                for i, path in enumerate(paths):
-                    adapter = illumina.util.ADAPTERS["Nextera"][i]
-                    fastq_in = str(path)
-                    fastq_out = self.task_path(
-                        readfile=path,
-                        taskname=self.TASK_TRIM,
-                        subdir="trimmed",
-                        suffix=".trimmed.fastq",
-                        r1only=False)
-                    args = ["cutadapt", "-a", adapter, "-o", fastq_out, fastq_in]
-                    # Call cutadapt with each file.  If the exit status is
-                    # nonzero or if the expected output file is missing, raise
-                    # an exception.
-                    subprocess.run(args, stdout=fout, stderr=fout, check=True)
-                    if not Path(fastq_out).exists():
-                        msg = "missing output file %s" % fastq_out
-                        raise ProjectError(msg)
-
-    ### Merge
-
-    def _merge_pair(self, fq_out, fqs_in):
-        with open(fq_out, "w") as f_out, \
-                open(fqs_in[0], "r") as f_r1, \
-                open(fqs_in[1], "r") as f_r2:
-            riter1 = SeqIO.parse(f_r1, "fastq")
-            riter2 = SeqIO.parse(f_r2, "fastq")
-            for rec1, rec2 in zip(riter1, riter2):
-                SeqIO.write(rec1, f_out, "fastq")
-                SeqIO.write(rec2, f_out, "fastq")
-
-    def merge(self):
-        """Interleave forward and reverse reads for each sample."""
-        with open(self._log_path("merge"), "w") as fout:
-            try:
-                for samp in self.sample_paths.keys():
-                    paths = self.sample_paths[samp]
-                    if len(paths) != 2:
-                        raise ProjectError("merging needs 2 files per sample")
-                    get_tp = lambda p: self.task_path(p, "trim", "trimmed", ".trimmed.fastq", r1only=False)
-                    fqs_in = [get_tp(p) for p in paths]
-                    fq_out = self.task_path(paths[0],
-                                            "merge",
-                                            "PairedReads",
-                                            ".merged.fastq")
-                    self._merge_pair(fq_out, fqs_in)
-                    # Merge each file pair. If the expected output file is missing,
-                    # raise an exception.
-                    if not Path(fq_out).exists():
-                        msg = "missing output file %s" % fq_out
-                        raise ProjectError(msg)
-            except Exception as exception:
-                msg = traceback.format_exc()
-                fout.write(msg + "\n")
-                raise exception
-
-    ### Assemble
-
-    def _assemble_reads(self, fq_in, dir_out, f_log):
-        """Assemble a pair of read files with SPAdes.
-
-        This runs spades.py on a single sample, saving the output to a given
-        directory.  The contigs, if built, will be in contigs.fasta.  Spades
-        seems to crash a lot so if anything goes wrong we just create an empty
-        contigs.fasta in the directory and log the error."""
-        fp_out = dir_out / "contigs.fasta"
-        # Spades always fails for empty input, so we'll explicitly skip that
-        # case.  It might crash anyway, so we handle that below too.
-        if Path(fq_in).stat().st_size == 0:
-            f_log.write("Skipping assembly for empty file: %s\n" % str(fq_in))
-            f_log.write("creating placeholder contig file.\n")
-            touch(fp_out)
-            return fp_out
-        args = ["spades.py", "--12", fq_in,
-                "-o", dir_out,
-                "-t", self.nthreads,
-                "--phred-offset", self.phred_offset]
-        args = [str(x) for x in args]
-        # spades tends to throw nonzero exit codes with short files, empty
-        # files, etc.   If something goes wrong during assembly we'll just make
-        # a stub file and move on.
-        try:
-            subprocess.run(args, stdout=f_log, stderr=f_log, check=True)
-        except subprocess.CalledProcessError:
-            f_log.write("spades exited with errors.\n")
-            f_log.write("creating placeholder contig file.\n")
-            touch(fp_out)
-        return fp_out
-
-    def _prep_contigs_for_geneious(self, fa_in, fq_out):
-        """Filter and format contigs for use in Geneious.
-
-        Keep contigs above a length threshold, and fake quality scores so we
-        can get a FASTQ file to combine with the reads in the next step.
-        Modify the sequence ID line to be: <sample>-contig_<contig_number>
-        """
-        match = re.match("(.*)\\.contigs\\.fastq$", fq_out.name)
-        sample_prefix = match.group(1)
-        with open(fq_out, "w") as f_out, open(fa_in, "r") as f_in:
-            for rec in SeqIO.parse(f_in, "fasta"):
-                if len(rec.seq) > self.contig_length_min:
-                    rec.letter_annotations["phred_quality"] = [40]*len(rec.seq)
-                    match = re.match("^NODE_([0-9])+_.*", rec.id)
-                    contig_num = match.group(1)
-                    rec.id = "%s-contig_%s" % (sample_prefix, contig_num)
-                    rec.description = ""
-                    SeqIO.write(rec, f_out, "fastq")
-
-    def _combine_contigs_for_geneious(self, fq_contigs, fq_reads, fq_out):
-        """Concatenate formatted contigs and merged reads for Geneious."""
-        with open(fq_contigs) as f_contigs, open(fq_reads) as f_reads, open(fq_out, "w") as f_out:
-            for line in f_contigs:
-                f_out.write(line)
-            for line in f_reads:
-                f_out.write(line)
-
-    def assemble(self):
-        """Assemble contigs from all samples.
-
-        This handles de-novo assembly with Spades and some of our own
-        post-processing."""
-        with open(self._log_path("assemble"), "w") as fout:
-            try:
-                for samp in self.sample_paths.keys():
-                    # Set up paths to use
-                    paths = self.sample_paths[samp]
-                    fq_merged = self.task_path(paths[0],
-                                               self.TASK_MERGE,
-                                               "PairedReads",
-                                               ".merged.fastq")
-                    fq_contigs = self.task_path(paths[0],
-                                                self.TASK_ASSEMBLE,
-                                                "ContigsGeneious",
-                                                ".contigs.fastq")
-                    fq_combo = self.task_path(paths[0],
-                                              self.TASK_ASSEMBLE,
-                                              "CombinedGeneious",
-                                              ".contigs_reads.fastq")
-                    spades_dir = self.task_path(paths[0], self.TASK_ASSEMBLE, "assembled")
-                    # Assemble and post-process: create FASTQ version for all
-                    # contigs above a given length, using altered sequence
-                    # descriptions, and then combine with the original reads.
-                    fa_contigs = self._assemble_reads(fq_merged, spades_dir, fout)
-                    self._prep_contigs_for_geneious(fa_contigs, fq_contigs)
-                    self._combine_contigs_for_geneious(fq_contigs, fq_merged, fq_combo)
-            except Exception as exception:
-                msg = traceback.format_exc()
-                fout.write(msg + "\n")
-                raise exception
-
-    ### Zip
-
-    def zip(self):
-        """Create zipfile of processing directory and metadata."""
-        mkparent(self.path_pack)
-        # By default ZipFile will not actually compress!  We need to specify a
-        # compression method explicitly for that.
-        with zipfile.ZipFile(self.path_pack, "x", zipfile.ZIP_DEFLATED) as zipper:
-            # Archive everything in the processing directory
-            for root, dummy, files in os.walk(self.path_proc):
-                for fname in files:
-                    # Archive the file but trim the name so it's relative to
-                    # the processing directory.
-                    filename = os.path.join(root, fname)
-                    arcname = Path(filename).relative_to(self.path_proc.parent)
-                    zipper.write(filename, arcname)
-
-    ### Metadata
-
-    def copy_metadata(self):
-        """Copy metadata spreadsheets and YAML into working directory."""
-        dest = self._task_dir_parent(self.TASK_METADATA) / "Metadata"
-        dest.mkdir(parents=True, exist_ok=True)
-        paths = []
-        paths.append(self.alignment.path_sample_sheet) # Sample Sheet
-        paths.append(self.path) # Metadata YAML file (as it currently stands)
-        for path in paths:
-            shutil.copy(path, dest)
-        # metadata is special: need to filter out other projects
-        path_md_out = dest / self.exp_path.name
-        with open(self.exp_path) as f_in, open(path_md_out, "w") as f_out:
-            # Read in all the rows in the original metadata spreadsheet
-            reader = csv.DictReader(f_in)
-            data = list(reader)
-            # Here, write out the experiment spreadsheet but only include our
-            # rows
-            writer = csv.DictWriter(f_out, fieldnames=data[0].keys())
-            writer.writeheader()
-            for row in data:
-                if row["Project"] == self.name:
-                    writer.writerow(row)
-
-    ### Mail
-
-    def send_email(self):
-        """Send notfication email for a finished ProjectData."""
-        # Gather fields to fill in for the message
-        # (The name prefix is considered OK by RFC822, so we should be able to
-        # leave that intact for both the sending part and the "To:" field.)
-        contacts = self._metadata["experiment_info"]["contacts"]
-        contacts = ["%s <%s>" % (k, contacts[k]) for k in contacts]
-        url = self._metadata["task_output"].get("upload", {}).get("url", "")
-        subject = "Illumina Run Processing Complete for %s" % self.work_dir
-        # Build message text and html
-        body = "Hello,\n\n"
-        body += "Illumina run processing is complete for %s\n" % self.work_dir
-        body += "and a zip file with results can be downloaded from this url:\n"
-        body += "\n%s\n" % url
-        html = "Hello,\n"
-        html += "<br><br>\n\n"
-        html += "Illumina run processing is complete for %s\n" % self.work_dir
-        html += "and a zip file with results can be downloaded from this url:\n"
-        html += "<br><br>\n"
-        html += "\n<a href='%s'>%s</a>\n" % (url, url)
-        # Send
-        kwargs = {
-            "to_addrs": contacts,
-            "subject": subject,
-            "msg_body": body,
-            "msg_html": html
-            }
-        self.mailer(**kwargs)
-
     ###### Implementation Details
 
     def _setup_exp_info(self, exp_info_full):
@@ -694,122 +356,70 @@ class ProjectData:
                 if not sample_name in exp_info["sample_names"]:
                     exp_info["sample_names"].append(sample_name)
                 exp_info["contacts"].update(row["Contacts"])
-                for task in row["Tasks"]:
-                    if not task in exp_info["tasks"]:
-                        exp_info["tasks"].append(task)
+                for taskname in row["Tasks"]:
+                    if not taskname in exp_info["tasks"]:
+                        exp_info["tasks"].append(taskname)
         return exp_info
 
+    def _setup_tasks(self):
+        """Create the list of Task objects.
+
+        This will take into account any defaults defined and dependencies of
+        each task."""
+        # dictionary of name/class pairs
+        tasks_all = task.task_classes()
+        # explicitly-requested tasks
+        tasknames = self.experiment_info["tasks"][:]
+        # handle no-task case and add any defaults
+        if not tasknames:
+            tasknames = self.config["task_null"]
+        tasknames += self.config["task_defaults"]
+        # Add in dependencies for any that exist.
+        deps = set()
+        for taskname in tasknames:
+            deps.update(self.__deps_for(taskname))
+        tasknames += deps
+        # Keep unique only.
+        tasknames = list(set(tasknames))
+        # Instantiate each one by name.  Each object gets a dedicated config
+        # dictionary and a reference to this ProjectData object.
+        tasks = []
+        for taskname in tasknames:
+            cls = tasks_all[taskname]
+            config = self.config["tasks"].get(taskname, {})
+            obj = cls(config, self)
+            tasks.append(obj)
+        # Sort by the order attribute of each task.
+        tasks = sorted(tasks)
+        return tasks
+
+    def __deps_for(self, taskname, total=None):
+        """Get all dependent tasks' names (including indirect) for one task."""
+        # Set of all dependencies seen so far.
+        tasks_all = task.task_classes()
+        if not total:
+            total = set()
+        for dep in tasks_all[taskname].dependencies:
+            if dep not in total:
+                total.update(self.__deps_for(dep, total))
+            total.add(dep)
+        return total
+
     def _setup_task_status(self):
-        tasks = self.experiment_info["tasks"][:]
-        tasks = self._normalize_tasks(tasks)
         task_status = {}
-        task_status["pending"] = tasks
+        task_status["pending"] = [task.name for task in self.tasks]
         task_status["completed"] = []
         task_status["current"] = ""
         return task_status
 
-    def _normalize_tasks(self, tasks):
-        """Add default and dependency tasks and order as needed."""
-        # Add in any defaults.  If nothing is given, always include the
-        # default.
-        if not tasks:
-            tasks = ProjectData.TASK_NULL[:]
-        tasks += ProjectData.TASK_DEFAULTS
-        # Add in dependencies for any that exist.
-        deps = set()
-        for task in tasks:
-            deps.update(self._deps_for(task))
-        tasks += deps
-        # Keep unique only.
-        tasks = list(set(tasks))
-        # order and verify.  We'll get a ValueError from index() if any of
-        # these are not found.
-        indexes = [ProjectData.TASKS.index(t) for t in tasks]
-        tasks = [t for _, t in sorted(zip(indexes, tasks))]
-        return tasks
-
-    def _deps_for(self, task, total=None):
-        """Get all dependent tasks (including indirect) for one task."""
-        # Set of all dependencies seen so far.
-        if not total:
-            total = set()
-        deps = ProjectData.TASK_DEPS.get(task, set())
-        for dep in deps:
-            if dep not in total:
-                total.update(self._deps_for(dep, total))
-            total.add(dep)
-        return total
-
-    def _run_task(self, task):
+    def _run_task(self, taskname):
         """Process the next pending task."""
 
-        msg = "ProjectData processing: %s, task: %s" % (self.work_dir, task)
+        msg = "ProjectData processing: %s, task: %s" % (self.work_dir, taskname)
         self.logger.debug(msg)
-
-        self._metadata["task_output"][task] = {}
-
-        # No-op: do nothing!
-        if task == ProjectData.TASK_NOOP:
-            pass
-
-        elif task == ProjectData.TASK_FAIL:
-            raise ProjectError("Failing ProjectData as requested")
-
-        # Copy run directory to within processing directory
-        elif task == ProjectData.TASK_COPY:
-            self.copy_run()
-
-        # Run cutadapt to trim the Illumina adapters
-        elif task == ProjectData.TASK_TRIM:
-            self.trim()
-
-        # Interleave the read pairs
-        elif task == ProjectData.TASK_MERGE:
-            self.merge()
-
-        # Run SPAdes to assemble contigs from the interleaved files
-        elif task == ProjectData.TASK_ASSEMBLE:
-            self.assemble()
-
-        # Wait for a "Manual" subdirectory to appear in the processing
-        # directory.
-        elif task == ProjectData.TASK_MANUAL:
-            while not (self.path_proc / "Manual").exists():
-                time.sleep(1)
-
-        # Wait for a "Geneious" subdirectory to appear in the processing
-        # directory.
-        elif task == ProjectData.TASK_GENEIOUS:
-            # Override the implicit task hiding for this specific case.  This
-            # is brittle but should work for the time being.
-            paths_move = [
-                self._task_dir_parent(self.TASK_MERGE)/"PairedReads",
-                self._task_dir_parent(self.TASK_ASSEMBLE)/"ContigsGeneious",
-                self._task_dir_parent(self.TASK_ASSEMBLE)/"CombinedGeneious"
-                ]
-            for p in paths_move:
-                if p.parent != self.path_proc:
-                    shutil.move(str(p), str(self.path_proc))
-            while not (self.path_proc / "Geneious").exists():
-                time.sleep(1)
-
-        # Copy over metadata to working directory
-        elif task == ProjectData.TASK_METADATA:
-            self.copy_metadata()
-
-        # Zip up all files in the processing directory
-        elif task == ProjectData.TASK_PACKAGE:
-            self.zip()
-
-        # Upload the zip archive to Box
-        elif task == ProjectData.TASK_UPLOAD:
-            url = self.uploader(path=self.path_pack)
-            self._metadata["task_output"][task] = {"url": url}
-
-        # Email contacts with link to Box download
-        elif task == ProjectData.TASK_EMAIL:
-            self.send_email()
-
-        # This should never happen (so it probably will).
-        else:
-            raise ProjectError("task \"%s\" not recognized" % task)
+        # match name to object
+        taskobj = next(task for task in self.tasks if task.name == taskname)
+        if not taskobj:
+            # This should never happen (so it probably will).
+            raise ProjectError("task \"%s\" not recognized" % taskname)
+        self._metadata["task_output"][taskname] = taskobj.run() or {}

--- a/umbra/task/__init__.py
+++ b/umbra/task/__init__.py
@@ -1,0 +1,199 @@
+"""
+The core task functionality for processing.
+
+Add-on tasks should be subclasses of the base class Task.  Tasks are
+instantiated by ProjectData objects for individual datasets.
+"""
+
+import re
+import importlib
+import pkgutil
+import sys
+import logging
+from pathlib import Path
+from ..util import mkparent
+
+# requires on PATH:
+#  * cutadapt
+#  * spades.py
+
+LOGGER = logging.getLogger(__name__)
+
+def task_classes():
+    """A dict of available Task classes in this module, by name.
+
+    This relies on the "name" attribute of each object beginning with "Task" in
+    this module, and excludes the TaskParent meta-class and the Task base
+    class."""
+    objs = globals()
+    keeps = lambda n: n.startswith("Task") and n != "Task"
+    tasks = {objs[n].name: objs[n] for n in objs if keeps(n)}
+    return tasks
+
+def __load_task_classes():
+    """Load classes from within this package whose names start with "Task".
+
+    The idea here is that each task is in its own module, largely independent
+    except for what the task class inherits from its parents.  After this is
+    executed, task_classes() should produce a complete dictionary of available
+    tasks.
+    """
+    package = sys.modules[__package__]
+    for _, modname, _ in pkgutil.walk_packages(package.__path__,
+                                               package.__name__+"."):
+        mod = importlib.import_module(modname, __package__)
+        for name in dir(mod):
+            if name.startswith("Task"):
+                LOGGER.debug("Importing into %s: %s (from %s)",
+                             __package__, name, mod)
+                globals()[name] = getattr(mod, name)
+
+
+# pylint: disable=invalid-name
+class __TaskParent(type):
+    """A class for Task classes.
+
+    This lets us add some class-level automatic magic to any Task classes.
+    There's nothing much to see here, you probably want Task instead.
+    """
+
+    def __new__(cls, clsname, superclasses, attrs):
+        # Define a name attribute for the class.  I'm doing it this roundabout
+        # meta way so that we can easily have each Task class have a name
+        # attribute (and not just each instance of the class) automatically.
+        attrs["name"] = clsname
+        name = clsname.replace("Task", "", 1).lower()
+        if name != "":
+            attrs["name"] = name
+        # Store a reference to the original module the class came from.  Useful
+        # when we have a mix of built-in and custom tasks.
+        # TODO hmm, doesn't work quite right yet.  Everything shows up as here.
+        # Maybe because of my namespace-mangling magic?  Or because the package
+        # path really is always the same?
+        #attrs["task_module"] = Path(package.__path__[0])
+
+        def task_module():
+            package = sys.modules[__package__]
+            print(dir(package))
+            print(__file__)
+            print(__name__)
+            print(__path__)
+            print('')
+
+        attrs["task_module"] = task_module
+
+        return type.__new__(cls, clsname, superclasses, attrs)
+
+
+class Task(metaclass=__TaskParent):
+    """Base class for a processing task.
+
+    To create a custom proessing task, make a sub-class of this class,
+    following the instructions here.  Set the docstring for the class to a
+    basic description of what the task does.
+
+    Use the helper method available via this class to access file paths and run
+    information.
+    """
+
+    @property
+    def name(self):
+        """Name of this task, based on its class."""
+        return self.__class__.name
+
+    def __lt__(self, other):
+        """Define "<" operator which allows easy task sorting by order."""
+        # https://stackoverflow.com/a/4010558
+        return self.order < other.order
+
+    # Task execution order.
+    # A higher number means run later than tasks with lower numbers.  This
+    # default setting will run after the core processing tasks but before the
+    # final package/upload/email set of tasks.
+    order = 100
+
+    # List of task names to implicitly requre.
+    # Tasks in the returned list will be automatically included in the set of
+    # tasks executed.  (Note that run order is determined by each task's order
+    # property; there is no real resolution of dependencies in a graph-like
+    # way.)
+    dependencies = []
+
+    @property
+    def log_path(self):
+        """Path to log file for this task."""
+        path = (self.proj.path_proc /
+                self.proj.config.get("log_path", "logs") /
+                ("log_" + self.name + ".txt")).resolve()
+        mkparent(path)
+        return path
+
+    @property
+    def nthreads(self):
+        """Max number of threads to be used in processing.
+
+        This is just an integer hint for any subprocesses started here.  The
+        task itself will always run within a single thread.
+        """
+        return self.proj.nthreads
+
+    def __init__(self, config, proj):
+        """Task object initlization.
+
+        When a task is created it will be given a dictionary of configuration
+        information and a project data object with a bundle of run information
+        and metadata.  If you override __init__ be sure to handle this part or
+        super().__init__(config, proj).
+        """
+        self.config = config
+        self.proj = proj
+
+    def run(self):
+        """The core functionality for the task.
+
+        Override this method in your own task.  This will be called when it is
+        time to actually execute the task.
+
+        Any exceptions raised once a task is initialized are caught during
+        processing, logged, and used to mark the project as failed.  If run()
+        completes without exceptions success is assumed and the next task is
+        executed.  umbra.util.ProjectError can be used for recognized types of
+        failure, but it's treated the same as any exception.
+
+        The return value from here will be added to the dictionary of
+        processing information for the project and serialized to YAML on disk,
+        so if giving a return value be sure to use just basic types that won't
+        cause trouble (no arbitrary objects).  The None object is fine.
+        """
+        raise NotImplementedError
+
+    @property
+    def sample_paths(self):
+        """Dict mapping sample names to filesystem paths."""
+        return self.proj.sample_paths
+
+    def task_path(self, readfile, taskname, subdir, suffix="", r1only=True):
+        """Give readfile-related path, following the originals' name."""
+        pat = "(.*_L[0-9]+_)R([12])(_001)\\.fastq\\.gz"
+        if r1only:
+            name = re.sub(pat, "\\1R\\3" + suffix, readfile.name)
+        else:
+            name = re.sub(pat, "\\1R\\2\\3" + suffix, readfile.name)
+        fastq_out = self._task_dir_parent(taskname) / subdir / name
+        mkparent(fastq_out)
+        return fastq_out
+
+    def _task_dir_parent(self, taskname):
+        """Give processing parent path for a given task.
+
+        This will take into account configuration settings for the project and
+        the specific task, if present.  If all defaults are set this will just
+        be the processing directory.
+        """
+        path_implicit = "."
+        if taskname not in self.proj.experiment_info["tasks"]:
+            path_implicit = self.proj.config.get("implicit_tasks_path", ".")
+        path = (self.proj.path_proc / path_implicit).resolve()
+        return path
+
+__load_task_classes()

--- a/umbra/task/task_assemble.py
+++ b/umbra/task/task_assemble.py
@@ -1,0 +1,107 @@
+"""Assemble contigs from all samples."""
+
+import subprocess
+import re
+import traceback
+from pathlib import Path
+from Bio import SeqIO
+from umbra import task
+from umbra.util import touch
+
+class TaskAssemble(task.Task):
+    """Assemble contigs from all samples.
+
+    This handles de-novo assembly with Spades and some of our own
+    post-processing."""
+
+    order = 12
+    dependencies = ["merge"]
+
+    def run(self):
+        with open(self.log_path, "w") as fout:
+            try:
+                for samp in self.sample_paths.keys():
+                    # Set up paths to use
+                    paths = self.sample_paths[samp]
+                    fq_merged = self.task_path(paths[0],
+                                               "merge",
+                                               "PairedReads",
+                                               ".merged.fastq")
+                    fq_contigs = self.task_path(paths[0],
+                                                "assemble",
+                                                "ContigsGeneious",
+                                                ".contigs.fastq")
+                    fq_combo = self.task_path(paths[0],
+                                              "assemble",
+                                              "CombinedGeneious",
+                                              ".contigs_reads.fastq")
+                    spades_dir = self.task_path(paths[0], "assemble", "assembled")
+                    # Assemble and post-process: create FASTQ version for all
+                    # contigs above a given length, using altered sequence
+                    # descriptions, and then combine with the original reads.
+                    fa_contigs = self._assemble_reads(fq_merged, spades_dir, fout)
+                    self._prep_contigs_for_geneious(fa_contigs, fq_contigs)
+                    _combine_contigs_for_geneious(fq_contigs, fq_merged, fq_combo)
+            except Exception as exception:
+                msg = traceback.format_exc()
+                fout.write(msg + "\n")
+                raise exception
+
+    def _assemble_reads(self, fq_in, dir_out, f_log):
+        """Assemble a pair of read files with SPAdes.
+
+        This runs spades.py on a single sample, saving the output to a given
+        directory.  The contigs, if built, will be in contigs.fasta.  Spades
+        seems to crash a lot so if anything goes wrong we just create an empty
+        contigs.fasta in the directory and log the error."""
+        fp_out = dir_out / "contigs.fasta"
+        # Spades always fails for empty input, so we'll explicitly skip that
+        # case.  It might crash anyway, so we handle that below too.
+        if Path(fq_in).stat().st_size == 0:
+            f_log.write("Skipping assembly for empty file: %s\n" % str(fq_in))
+            f_log.write("creating placeholder contig file.\n")
+            touch(fp_out)
+            return fp_out
+        args = ["spades.py", "--12", fq_in,
+                "-o", dir_out,
+                "-t", self.nthreads,
+                "--phred-offset", self.config["phred_offset"]]
+        args = [str(x) for x in args]
+        # spades tends to throw nonzero exit codes with short files, empty
+        # files, etc.   If something goes wrong during assembly we'll just make
+        # a stub file and move on.
+        try:
+            subprocess.run(args, stdout=f_log, stderr=f_log, check=True)
+        except subprocess.CalledProcessError:
+            f_log.write("spades exited with errors.\n")
+            f_log.write("creating placeholder contig file.\n")
+            touch(fp_out)
+        return fp_out
+
+    def _prep_contigs_for_geneious(self, fa_in, fq_out):
+        """Filter and format contigs for use in Geneious.
+
+        Keep contigs above a length threshold, and fake quality scores so we
+        can get a FASTQ file to combine with the reads in the next step.
+        Modify the sequence ID line to be: <sample>-contig_<contig_number>
+        """
+        match = re.match("(.*)\\.contigs\\.fastq$", fq_out.name)
+        sample_prefix = match.group(1)
+        with open(fq_out, "w") as f_out, open(fa_in, "r") as f_in:
+            for rec in SeqIO.parse(f_in, "fasta"):
+                if len(rec.seq) > self.config["contig_length_min"]:
+                    rec.letter_annotations["phred_quality"] = [40]*len(rec.seq)
+                    match = re.match("^NODE_([0-9])+_.*", rec.id)
+                    contig_num = match.group(1)
+                    rec.id = "%s-contig_%s" % (sample_prefix, contig_num)
+                    rec.description = ""
+                    SeqIO.write(rec, f_out, "fastq")
+
+
+def _combine_contigs_for_geneious(fq_contigs, fq_reads, fq_out):
+    """Concatenate formatted contigs and merged reads for Geneious."""
+    with open(fq_contigs) as f_contigs, open(fq_reads) as f_reads, open(fq_out, "w") as f_out:
+        for line in f_contigs:
+            f_out.write(line)
+        for line in f_reads:
+            f_out.write(line)

--- a/umbra/task/task_assemble.py
+++ b/umbra/task/task_assemble.py
@@ -1,9 +1,8 @@
 """Assemble contigs from all samples."""
 
-import subprocess
 import re
-import traceback
 from pathlib import Path
+from subprocess import CalledProcessError
 from Bio import SeqIO
 from umbra import task
 from umbra.util import touch
@@ -18,48 +17,43 @@ class TaskAssemble(task.Task):
     dependencies = ["merge"]
 
     def run(self):
-        with open(self.log_path, "w") as fout:
-            try:
-                for samp in self.sample_paths.keys():
-                    # Set up paths to use
-                    paths = self.sample_paths[samp]
-                    fq_merged = self.task_path(paths[0],
-                                               "merge",
-                                               "PairedReads",
-                                               ".merged.fastq")
-                    fq_contigs = self.task_path(paths[0],
-                                                "assemble",
-                                                "ContigsGeneious",
-                                                ".contigs.fastq")
-                    fq_combo = self.task_path(paths[0],
-                                              "assemble",
-                                              "CombinedGeneious",
-                                              ".contigs_reads.fastq")
-                    spades_dir = self.task_path(paths[0], "assemble", "assembled")
-                    # Assemble and post-process: create FASTQ version for all
-                    # contigs above a given length, using altered sequence
-                    # descriptions, and then combine with the original reads.
-                    fa_contigs = self._assemble_reads(fq_merged, spades_dir, fout)
-                    self._prep_contigs_for_geneious(fa_contigs, fq_contigs)
-                    _combine_contigs_for_geneious(fq_contigs, fq_merged, fq_combo)
-            except Exception as exception:
-                msg = traceback.format_exc()
-                fout.write(msg + "\n")
-                raise exception
+        for samp in self.sample_paths.keys():
+            # Set up paths to use
+            paths = self.sample_paths[samp]
+            fq_merged = self.task_path(paths[0],
+                                       "merge",
+                                       "PairedReads",
+                                       ".merged.fastq")
+            fq_contigs = self.task_path(paths[0],
+                                        "assemble",
+                                        "ContigsGeneious",
+                                        ".contigs.fastq")
+            fq_combo = self.task_path(paths[0],
+                                      "assemble",
+                                      "CombinedGeneious",
+                                      ".contigs_reads.fastq")
+            spades_dir = self.task_path(paths[0], "assemble", "assembled")
+            # Assemble and post-process: create FASTQ version for all
+            # contigs above a given length, using altered sequence
+            # descriptions, and then combine with the original reads.
+            fa_contigs = self._assemble_reads(fq_merged, spades_dir)
+            self._prep_contigs_for_geneious(fa_contigs, fq_contigs)
+            _combine_contigs_for_geneious(fq_contigs, fq_merged, fq_combo)
 
-    def _assemble_reads(self, fq_in, dir_out, f_log):
+    def _assemble_reads(self, fq_in, dir_out):
         """Assemble a pair of read files with SPAdes.
 
         This runs spades.py on a single sample, saving the output to a given
         directory.  The contigs, if built, will be in contigs.fasta.  Spades
         seems to crash a lot so if anything goes wrong we just create an empty
         contigs.fasta in the directory and log the error."""
+        self.log_setup()
         fp_out = dir_out / "contigs.fasta"
         # Spades always fails for empty input, so we'll explicitly skip that
         # case.  It might crash anyway, so we handle that below too.
         if Path(fq_in).stat().st_size == 0:
-            f_log.write("Skipping assembly for empty file: %s\n" % str(fq_in))
-            f_log.write("creating placeholder contig file.\n")
+            self.logf.write("Skipping assembly for empty file: %s\n" % str(fq_in))
+            self.logf.write("creating placeholder contig file.\n")
             touch(fp_out)
             return fp_out
         args = ["spades.py", "--12", fq_in,
@@ -71,10 +65,10 @@ class TaskAssemble(task.Task):
         # files, etc.   If something goes wrong during assembly we'll just make
         # a stub file and move on.
         try:
-            subprocess.run(args, stdout=f_log, stderr=f_log, check=True)
-        except subprocess.CalledProcessError:
-            f_log.write("spades exited with errors.\n")
-            f_log.write("creating placeholder contig file.\n")
+            self.runcmd(args)
+        except CalledProcessError:
+            self.logf.write("spades exited with errors.\n")
+            self.logf.write("creating placeholder contig file.\n")
             touch(fp_out)
         return fp_out
 

--- a/umbra/task/task_copy.py
+++ b/umbra/task/task_copy.py
@@ -1,0 +1,15 @@
+"""Copy the run directory into the processing directory."""
+
+from distutils.dir_util import copy_tree
+from umbra import task
+
+class TaskCopy(task.Task):
+    """Copy the run directory into the processing directory."""
+
+    order = 2
+
+    def run(self):
+        src = str(self.proj.alignment.run.path)
+        dest = str(self._task_dir_parent(self.name) /
+                   self.proj.alignment.run.run_id)
+        copy_tree(src, dest)

--- a/umbra/task/task_email.py
+++ b/umbra/task/task_email.py
@@ -1,0 +1,38 @@
+"""Send notfication email for a finished ProjectData."""
+
+from umbra import task
+class TaskEmail(task.Task):
+    """Send notfication email for a finished ProjectData."""
+
+    order = 1003
+    dependencies = ["upload"]
+
+    def run(self):
+        # TODO reorganize mailer and metadata
+        # Gather fields to fill in for the message
+        # (The name prefix is considered OK by RFC822, so we should be able to
+        # leave that intact for both the sending part and the "To:" field.)
+        contacts = self.proj._metadata["experiment_info"]["contacts"]
+        contacts = ["%s <%s>" % (k, contacts[k]) for k in contacts]
+        url = self.proj._metadata["task_output"].get("upload", {}).get("url", "")
+        subject = "Illumina Run Processing Complete for %s" % self.proj.work_dir
+        # Build message text and html
+        body = "Hello,\n\n"
+        body += "Illumina run processing is complete for %s\n" % self.proj.work_dir
+        body += "and a zip file with results can be downloaded from this url:\n"
+        body += "\n%s\n" % url
+        html = "Hello,\n"
+        html += "<br><br>\n\n"
+        html += "Illumina run processing is complete for %s\n" % self.proj.work_dir
+        html += "and a zip file with results can be downloaded from this url:\n"
+        html += "<br><br>\n"
+        html += "\n<a href='%s'>%s</a>\n" % (url, url)
+        # Send
+        kwargs = {
+            "to_addrs": contacts,
+            "subject": subject,
+            "msg_body": body,
+            "msg_html": html
+            }
+        self.proj.mailer(**kwargs)
+        return kwargs

--- a/umbra/task/task_fail.py
+++ b/umbra/task/task_fail.py
@@ -1,0 +1,15 @@
+"""Fail processing by raising an exception.
+
+This is a controlled failure case for testing and troubleshooting.  See also
+task_noop.py."""
+
+from umbra.util import ProjectError
+from umbra import task
+
+class TaskFail(task.Task):
+    """Fail processing by raising an exception."""
+
+    order = 1
+
+    def run(self):
+        raise ProjectError("Failing ProjectData as requested")

--- a/umbra/task/task_geneious.py
+++ b/umbra/task/task_geneious.py
@@ -1,0 +1,28 @@
+"""Prepare for special-case manual processing with Geneious."""
+
+import shutil
+import time
+from umbra import task
+
+class TaskGeneious(task.Task):
+    """Prepare for special-case manual processing with Geneious."""
+
+    order = 101
+
+    dependencies = ["assemble"]
+
+    def run(self):
+        # Wait for a "Geneious" subdirectory to appear in the processing
+        # directory.
+        # Override the implicit task hiding for this specific case.  This
+        # is brittle but should work for the time being.
+        paths_move = [
+            self._task_dir_parent("merge")/"PairedReads",
+            self._task_dir_parent("assemble")/"ContigsGeneious",
+            self._task_dir_parent("assemble")/"CombinedGeneious"
+            ]
+        for path in paths_move:
+            if path.parent != self.proj.path_proc:
+                shutil.move(str(path), str(self.proj.path_proc))
+        while not (self.proj.path_proc / "Geneious").exists():
+            time.sleep(1)

--- a/umbra/task/task_manual.py
+++ b/umbra/task/task_manual.py
@@ -1,0 +1,13 @@
+"""Wait for a "Manual" subdir to appear in the processing directory."""
+
+import time
+from umbra import task
+
+class TaskManual(task.Task):
+    """Wait for a "Manual" subdir to appear in the processing directory."""
+
+    order = 100
+
+    def run(self):
+        while not (self.proj.path_proc / "Manual").exists():
+            time.sleep(1)

--- a/umbra/task/task_merge.py
+++ b/umbra/task/task_merge.py
@@ -1,0 +1,50 @@
+"""Interleave forward and reverse reads for each sample."""
+
+import traceback
+from pathlib import Path
+from Bio import SeqIO
+from umbra import task
+from umbra.util import ProjectError
+
+class TaskMerge(task.Task):
+    """Interleave forward and reverse reads for each sample."""
+
+    order = 11
+    dependencies = ["trim"]
+
+    def run(self):
+        with open(self.log_path, "w") as fout:
+            try:
+                for samp in self.sample_paths.keys():
+                    paths = self.sample_paths[samp]
+                    if len(paths) != 2:
+                        raise ProjectError("merging needs 2 files per sample")
+                    fqs_in = [self._get_tp(p) for p in paths]
+                    fq_out = self.task_path(paths[0],
+                                            "merge",
+                                            "PairedReads",
+                                            ".merged.fastq")
+                    merge_pair(fq_out, fqs_in)
+                    # Merge each file pair. If the expected output file is missing,
+                    # raise an exception.
+                    if not Path(fq_out).exists():
+                        msg = "missing output file %s" % fq_out
+                        raise ProjectError(msg)
+            except Exception as exception:
+                msg = traceback.format_exc()
+                fout.write(msg + "\n")
+                raise exception
+
+    def _get_tp(self, path):
+        return self.task_path(path, "trim", "trimmed", ".trimmed.fastq",
+                              r1only=False)
+
+def merge_pair(fq_out, fqs_in):
+    with open(fq_out, "w") as f_out, \
+            open(fqs_in[0], "r") as f_r1, \
+            open(fqs_in[1], "r") as f_r2:
+        riter1 = SeqIO.parse(f_r1, "fastq")
+        riter2 = SeqIO.parse(f_r2, "fastq")
+        for rec1, rec2 in zip(riter1, riter2):
+            SeqIO.write(rec1, f_out, "fastq")
+            SeqIO.write(rec2, f_out, "fastq")

--- a/umbra/task/task_merge.py
+++ b/umbra/task/task_merge.py
@@ -1,6 +1,5 @@
 """Interleave forward and reverse reads for each sample."""
 
-import traceback
 from pathlib import Path
 from Bio import SeqIO
 from umbra import task
@@ -13,33 +12,28 @@ class TaskMerge(task.Task):
     dependencies = ["trim"]
 
     def run(self):
-        with open(self.log_path, "w") as fout:
-            try:
-                for samp in self.sample_paths.keys():
-                    paths = self.sample_paths[samp]
-                    if len(paths) != 2:
-                        raise ProjectError("merging needs 2 files per sample")
-                    fqs_in = [self._get_tp(p) for p in paths]
-                    fq_out = self.task_path(paths[0],
-                                            "merge",
-                                            "PairedReads",
-                                            ".merged.fastq")
-                    merge_pair(fq_out, fqs_in)
-                    # Merge each file pair. If the expected output file is missing,
-                    # raise an exception.
-                    if not Path(fq_out).exists():
-                        msg = "missing output file %s" % fq_out
-                        raise ProjectError(msg)
-            except Exception as exception:
-                msg = traceback.format_exc()
-                fout.write(msg + "\n")
-                raise exception
+        for samp in self.sample_paths.keys():
+            paths = self.sample_paths[samp]
+            if len(paths) != 2:
+                raise ProjectError("merging needs 2 files per sample")
+            fqs_in = [self._get_tp(p) for p in paths]
+            fq_out = self.task_path(paths[0],
+                                    "merge",
+                                    "PairedReads",
+                                    ".merged.fastq")
+            merge_pair(fq_out, fqs_in)
+            # Merge each file pair. If the expected output file is missing,
+            # raise an exception.
+            if not Path(fq_out).exists():
+                msg = "missing output file %s" % fq_out
+                raise ProjectError(msg)
 
     def _get_tp(self, path):
         return self.task_path(path, "trim", "trimmed", ".trimmed.fastq",
                               r1only=False)
 
 def merge_pair(fq_out, fqs_in):
+    """Merge reads from the pair of input FASTQs to a single output FASTQ."""
     with open(fq_out, "w") as f_out, \
             open(fqs_in[0], "r") as f_r1, \
             open(fqs_in[1], "r") as f_r2:

--- a/umbra/task/task_metadata.py
+++ b/umbra/task/task_metadata.py
@@ -1,0 +1,32 @@
+"""Copy metadata spreadsheets and YAML into working directory."""
+
+import shutil
+import csv
+from umbra import task
+
+class TaskMetadata(task.Task):
+    """Copy metadata spreadsheets and YAML into working directory."""
+
+    order = 1000
+
+    def run(self):
+        dest = self._task_dir_parent(self.name) / "Metadata"
+        dest.mkdir(parents=True, exist_ok=True)
+        paths = []
+        paths.append(self.proj.alignment.path_sample_sheet) # Sample Sheet
+        paths.append(self.proj.path) #  Project metadata YAML file (as it currently stands)
+        for path in paths:
+            shutil.copy(path, dest)
+        # metadata is special: need to filter out other projects
+        path_md_out = dest / self.proj.exp_path.name
+        with open(self.proj.exp_path) as f_in, open(path_md_out, "w") as f_out:
+            # Read in all the rows in the original metadata spreadsheet
+            reader = csv.DictReader(f_in)
+            data = list(reader)
+            # Here, write out the experiment spreadsheet but only include our
+            # rows
+            writer = csv.DictWriter(f_out, fieldnames=data[0].keys())
+            writer.writeheader()
+            for row in data:
+                if row["Project"] == self.proj.name:
+                    writer.writerow(row)

--- a/umbra/task/task_noop.py
+++ b/umbra/task/task_noop.py
@@ -1,0 +1,13 @@
+"""Do nothing at all.
+
+This is a minimal working example of a task module.  See also task_fail.py."""
+
+from umbra import task
+
+class TaskNoop(task.Task):
+    """Do nothing at all."""
+
+    order = 0
+
+    def run(self):
+        pass

--- a/umbra/task/task_package.py
+++ b/umbra/task/task_package.py
@@ -1,0 +1,27 @@
+"""Create zipfile of processing directory and metadata."""
+
+from pathlib import Path
+import zipfile
+import os
+from umbra import task
+from umbra.util import mkparent
+class TaskPackage(task.Task):
+    """Create zipfile of processing directory and metadata."""
+
+    order = 1001
+    dependencies = ["metadata"]
+
+    def run(self):
+        # TODO reorganize path_pack
+        mkparent(self.proj.path_pack)
+        # By default ZipFile will not actually compress!  We need to specify a
+        # compression method explicitly for that.
+        with zipfile.ZipFile(self.proj.path_pack, "x", zipfile.ZIP_DEFLATED) as zipper:
+            # Archive everything in the processing directory
+            for root, dummy, files in os.walk(self.proj.path_proc):
+                for fname in files:
+                    # Archive the file but trim the name so it's relative to
+                    # the processing directory.
+                    filename = os.path.join(root, fname)
+                    arcname = Path(filename).relative_to(self.proj.path_proc.parent)
+                    zipper.write(filename, arcname)

--- a/umbra/task/task_trim.py
+++ b/umbra/task/task_trim.py
@@ -1,6 +1,5 @@
 """Trim adapters from raw fastq.gz files."""
 
-import subprocess
 from pathlib import Path
 from umbra.illumina.util import ADAPTERS
 from umbra.util import ProjectError
@@ -13,26 +12,24 @@ class TaskTrim(task.Task):
 
     def run(self):
         # For each sample, separately process the one or more associated files.
-        with open(self.log_path, "w") as fout:
-            for samp in self.sample_paths.keys():
-                paths = self.sample_paths[samp]
-                if len(paths) > 2:
-                    raise ProjectError("trimming can't handle >2 files per sample")
-                for i, path in enumerate(paths):
-                    adapter = ADAPTERS["Nextera"][i]
-                    fastq_in = str(path)
-                    fastq_out = self.task_path(
-                        readfile=path,
-                        taskname=self.name,
-                        subdir="trimmed",
-                        suffix=".trimmed.fastq",
-                        r1only=False)
-                    args = ["cutadapt", "-a", adapter, "-o", fastq_out, fastq_in]
-                    # Call cutadapt with each file.  If the exit status is
-                    # nonzero or if the expected output file is missing, raise
-                    # an exception.
-                    # TODO make helper method for this pattern, used also in task_assemble
-                    subprocess.run(args, stdout=fout, stderr=fout, check=True)
-                    if not Path(fastq_out).exists():
-                        msg = "missing output file %s" % fastq_out
-                        raise ProjectError(msg)
+        for samp in self.sample_paths.keys():
+            paths = self.sample_paths[samp]
+            if len(paths) > 2:
+                raise ProjectError("trimming can't handle >2 files per sample")
+            for i, path in enumerate(paths):
+                adapter = ADAPTERS["Nextera"][i]
+                fastq_in = str(path)
+                fastq_out = self.task_path(
+                    readfile=path,
+                    taskname=self.name,
+                    subdir="trimmed",
+                    suffix=".trimmed.fastq",
+                    r1only=False)
+                args = ["cutadapt", "-a", adapter, "-o", fastq_out, fastq_in]
+                # Call cutadapt with each file.  If the exit status is
+                # nonzero or if the expected output file is missing, this will
+                # raise an exception.
+                self.runcmd(args)
+                if not Path(fastq_out).exists():
+                    msg = "missing output file %s" % fastq_out
+                    raise ProjectError(msg)

--- a/umbra/task/task_trim.py
+++ b/umbra/task/task_trim.py
@@ -1,0 +1,38 @@
+"""Trim adapters from raw fastq.gz files."""
+
+import subprocess
+from pathlib import Path
+from umbra.illumina.util import ADAPTERS
+from umbra.util import ProjectError
+from umbra import task
+
+class TaskTrim(task.Task):
+    """Trim adapters from raw fastq.gz files."""
+
+    order = 10
+
+    def run(self):
+        # For each sample, separately process the one or more associated files.
+        with open(self.log_path, "w") as fout:
+            for samp in self.sample_paths.keys():
+                paths = self.sample_paths[samp]
+                if len(paths) > 2:
+                    raise ProjectError("trimming can't handle >2 files per sample")
+                for i, path in enumerate(paths):
+                    adapter = ADAPTERS["Nextera"][i]
+                    fastq_in = str(path)
+                    fastq_out = self.task_path(
+                        readfile=path,
+                        taskname=self.name,
+                        subdir="trimmed",
+                        suffix=".trimmed.fastq",
+                        r1only=False)
+                    args = ["cutadapt", "-a", adapter, "-o", fastq_out, fastq_in]
+                    # Call cutadapt with each file.  If the exit status is
+                    # nonzero or if the expected output file is missing, raise
+                    # an exception.
+                    # TODO make helper method for this pattern, used also in task_assemble
+                    subprocess.run(args, stdout=fout, stderr=fout, check=True)
+                    if not Path(fastq_out).exists():
+                        msg = "missing output file %s" % fastq_out
+                        raise ProjectError(msg)

--- a/umbra/task/task_upload.py
+++ b/umbra/task/task_upload.py
@@ -1,0 +1,13 @@
+"""Upload zipfile to Box."""
+
+from umbra import task
+class TaskUpload(task.Task):
+    """Upload zipfile to Box."""
+
+    order = 1002
+    dependencies = ["package"]
+
+    def run(self):
+        # TODO reorganize uploader
+        url = self.proj.uploader(path=self.proj.path_pack)
+        return {"url": url}

--- a/umbra/util.py
+++ b/umbra/util.py
@@ -11,6 +11,9 @@ import time
 import warnings
 import yaml
 
+class ProjectError(Exception):
+    """Any sort of project-related exception."""
+
 def slugify(text, mask="_"):
     """Create a short, simple text string from the given input text."""
     pat = "[^A-Za-z0-9-_]"


### PR DESCRIPTION
This restructures the processing tasks into individual classes under a new `task` package, with one class per task and centralizing common parts in a parent `Task` class.  This paves the way for custom add-on tasks and shrinks down the overgrown `ProjectData` class.