### PR TITLE
Always explicit tasks

### DIFF
--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -50,6 +50,9 @@ task_options:
   # the project) task output directories.  By default these are stored
   # side-by-side on the top level with the rest of the per-task directories.
   implicit_tasks_path: ""
+  # List of task names whose output should always be kept at the top level (if
+  # present) whether explicitly or implicitly included.
+  always_explicit_tasks: [ ]
   # Subdirectory to use for per-task log files.
   log_path: "logs"
   # These tasks will always be executed

--- a/umbra/task/__init__.py
+++ b/umbra/task/__init__.py
@@ -253,7 +253,9 @@ class Task(metaclass=__TaskParent):
         be the processing directory.
         """
         path_implicit = "."
-        if taskname not in self.proj.experiment_info["tasks"]:
+        implicit = taskname not in self.proj.experiment_info["tasks"]
+        explicit = taskname in self.proj.config.get("always_explicit_tasks", [])
+        if implicit and not explicit:
             path_implicit = self.proj.config.get("implicit_tasks_path", ".")
         path = (self.proj.path_proc / path_implicit).resolve()
         return path


### PR DESCRIPTION
This adds a feature to override the `implicit_tasks_path` setting for specific named tasks.