### PR TITLE
Tidy code structure in umbra and test_umbra packages

### DIFF
--- a/test_umbra/test_box_uploader.py
+++ b/test_umbra/test_box_uploader.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 """
-Tests for BoxUploader objects.
+Test umbra.box_uploader
 
-If a file with real Box API credentials are supplied via the configuration, a
-live test will be run, over the Box API.  Otherwise Box tests are skipped.
+More specifically, tests for BoxUploader objects.  If a file with real Box API
+credentials are supplied via the configuration, a live test will be run, over
+the Box API.  Otherwise Box tests are skipped.
 """
 
 import urllib.request
@@ -12,17 +13,18 @@ from tempfile import NamedTemporaryFile
 from umbra.box_uploader import BoxUploader
 from .test_common import CONFIG
 
-config = CONFIG.get("box", {})
 
 class TestBoxUploader(unittest.TestCase):
+    """Test the BoxUploader class that handles file uploads to box.com."""
 
     def setUp(self):
+        box_config = CONFIG.get("box", {})
         msg = "Box credentials not supplied."
         try:
-            path = config.get("credentials_path")
+            path = box_config.get("credentials_path")
             if not path:
                 raise unittest.SkipTest(msg)
-            self.box = BoxUploader(path, config)
+            self.box = BoxUploader(path, box_config)
         except FileNotFoundError:
             raise unittest.SkipTest(msg)
 
@@ -31,13 +33,14 @@ class TestBoxUploader(unittest.TestCase):
             item.delete()
 
     def test_upload(self):
+        """Test uploading a file to Box."""
         data_exp = b"test_upload\n"
-        with NamedTemporaryFile() as f:
-            f.write(data_exp)
-            f.flush()
-            url = self.box.upload(f.name, "test_upload.txt")
-        with urllib.request.urlopen(url) as f:
-            data_obs = f.read()
+        with NamedTemporaryFile() as ftmp:
+            ftmp.write(data_exp)
+            ftmp.flush()
+            url = self.box.upload(ftmp.name, "test_upload.txt")
+        with urllib.request.urlopen(url) as furl:
+            data_obs = furl.read()
         self.assertEqual(data_obs, data_exp)
 
 

--- a/test_umbra/test_box_uploader.py
+++ b/test_umbra/test_box_uploader.py
@@ -6,9 +6,11 @@ If a file with real Box API credentials are supplied via the configuration, a
 live test will be run, over the Box API.  Otherwise Box tests are skipped.
 """
 
-from .test_common import *
 import urllib.request
+import unittest
+from tempfile import NamedTemporaryFile
 from umbra.box_uploader import BoxUploader
+from .test_common import CONFIG
 
 config = CONFIG.get("box", {})
 

--- a/test_umbra/test_box_uploader.py
+++ b/test_umbra/test_box_uploader.py
@@ -29,11 +29,12 @@ class TestBoxUploader(unittest.TestCase):
             raise unittest.SkipTest(msg)
 
     def tearDown(self):
-        for item in self.box._list():
+        for item in self.box.list():
             item.delete()
 
     def test_upload(self):
         """Test uploading a file to Box."""
+        self.assertEqual(len(self.box.list()), 0)
         data_exp = b"test_upload\n"
         with NamedTemporaryFile() as ftmp:
             ftmp.write(data_exp)
@@ -42,6 +43,7 @@ class TestBoxUploader(unittest.TestCase):
         with urllib.request.urlopen(url) as furl:
             data_obs = furl.read()
         self.assertEqual(data_obs, data_exp)
+        self.assertEqual(len(self.box.list()), 1)
 
 
 if __name__ == '__main__':

--- a/test_umbra/test_common.py
+++ b/test_umbra/test_common.py
@@ -31,38 +31,43 @@ class TestBase(unittest.TestCase):
     """Some setup/teardown shared with the real test classes."""
 
     def setUp(self):
-        self.setUpTmpdir()
-        self.setUpVars()
+        self.set_up_tmpdir()
+        self.set_up_vars()
 
     def tearDown(self):
         if TMP_PAUSE:
             sys.stderr.write("\n\ntmpdir = %s\n\n" % self.tmpdir.name)
             input()
-        self.tearDownTmpdir()
+        self.tear_down_tmpdir()
 
-    def setUpTmpdir(self):
-        # Make a full copy of the testdata to a temporary location
+    def set_up_tmpdir(self):
+        """Make a full copy of the testdata to a temporary location."""
         self.tmpdir = TemporaryDirectory()
         copy_tree(PATH_DATA, self.tmpdir.name)
-        self.path = Path(self.tmpdir.name)
-        self.path_runs = Path(self.tmpdir.name) / "runs"
-        self.path_exp = Path(self.tmpdir.name) / "experiments"
-        self.path_status = Path(self.tmpdir.name) / "status"
-        self.path_proc = Path(self.tmpdir.name) / "processed"
-        self.path_pack = Path(self.tmpdir.name) / "packaged"
-        self.path_report = Path(self.tmpdir.name) / "report.csv"
+        self.paths = {
+            "top":  Path(self.tmpdir.name),
+            "runs": Path(self.tmpdir.name) / "runs",
+            "exp": Path(self.tmpdir.name) / "experiments",
+            "status": Path(self.tmpdir.name) / "status",
+            "proc": Path(self.tmpdir.name) / "processed",
+            "pack": Path(self.tmpdir.name) / "packaged",
+            "report": Path(self.tmpdir.name) / "report.csv"
+            }
 
-    def setUpVars(self):
+    def set_up_vars(self):
+        """Initial variables for testing comparisons."""
         self.mails = []
 
-    def tearDownTmpdir(self):
+    def tear_down_tmpdir(self):
+        """Clean up temporary directory on disk."""
         # There's a bug where it'll raise a PermissionError if anything
         # write-protected ended up in the tmpdir.  So don't leave anything like
         # that lying around during a test!
         # https://bugs.python.org/issue26660
         self.tmpdir.cleanup()
 
-    def uploader(self, path):
+    @staticmethod
+    def uploader(path):
         """Mock of Box uploader function.
 
         This generates a Box-like URL for a supposedly-successful upload."""
@@ -78,7 +83,5 @@ class TestBase(unittest.TestCase):
         """Mock of Mailer.mail function.
 
         This accepts email parameters and just stores them."""
-        if not hasattr(self, "mails"):
-            self.mails = []
         self.mails.append(kwargs)
         return kwargs

--- a/test_umbra/test_common.py
+++ b/test_umbra/test_common.py
@@ -3,21 +3,12 @@ Common test code shared with the real tests.  Not much to see here.
 """
 
 import unittest
-from tempfile import TemporaryDirectory, NamedTemporaryFile
-from distutils.dir_util import copy_tree, remove_tree, mkpath
-from distutils.file_util import copy_file
+from tempfile import TemporaryDirectory
+from distutils.dir_util import copy_tree
 from pathlib import Path
-import logging
-import re
-import csv
 import hashlib
 import sys
-
-import umbra
-from umbra import (illumina,  util)
-from umbra.project import (ProjectData, ProjectError)
-from umbra.illumina.run import Run
-from umbra.illumina.alignment import Alignment
+from umbra import util
 
 PATH_ROOT = Path(__file__).parent
 PATH_DATA = PATH_ROOT / "data"
@@ -34,7 +25,7 @@ def md5(text):
         text = text.encode("utf-8")
     except AttributeError:
         pass
-    return(hashlib.md5(text).hexdigest())
+    return hashlib.md5(text).hexdigest()
 
 class TestBase(unittest.TestCase):
     """Some setup/teardown shared with the real test classes."""
@@ -54,11 +45,11 @@ class TestBase(unittest.TestCase):
         self.tmpdir = TemporaryDirectory()
         copy_tree(PATH_DATA, self.tmpdir.name)
         self.path = Path(self.tmpdir.name)
-        self.path_runs   = Path(self.tmpdir.name) / "runs"
-        self.path_exp    = Path(self.tmpdir.name) / "experiments"
+        self.path_runs = Path(self.tmpdir.name) / "runs"
+        self.path_exp = Path(self.tmpdir.name) / "experiments"
         self.path_status = Path(self.tmpdir.name) / "status"
-        self.path_proc   = Path(self.tmpdir.name) / "processed"
-        self.path_pack   = Path(self.tmpdir.name) / "packaged"
+        self.path_proc = Path(self.tmpdir.name) / "processed"
+        self.path_pack = Path(self.tmpdir.name) / "packaged"
         self.path_report = Path(self.tmpdir.name) / "report.csv"
 
     def setUpVars(self):
@@ -73,7 +64,7 @@ class TestBase(unittest.TestCase):
 
     def uploader(self, path):
         """Mock of Box uploader function.
-        
+
         This generates a Box-like URL for a supposedly-successful upload."""
         prefix = "https://domain.box.com/shared/static/"
         # Box uses 32 lowercase alphanumeric characters (a-z, 0-9).  Not sure
@@ -81,13 +72,13 @@ class TestBase(unittest.TestCase):
         checksum = md5(Path(path).name)
         suffix = Path(path).suffix
         url = prefix + checksum + suffix
-        return(url)
+        return url
 
     def mailer(self, **kwargs):
         """Mock of Mailer.mail function.
-        
+
         This accepts email parameters and just stores them."""
         if not hasattr(self, "mails"):
             self.mails = []
         self.mails.append(kwargs)
-        return(kwargs)
+        return kwargs

--- a/test_umbra/test_config.py
+++ b/test_umbra/test_config.py
@@ -6,25 +6,25 @@ Tests for config module functions.
 import unittest
 from pathlib import Path
 from umbra import config
-import umbra.config
 
 class TestConfig(unittest.TestCase):
+    """Test the config module that handles configuration optons."""
 
     def setUp(self):
         self.configs = ["", "install", "report"]
-        self.config_root = Path(umbra.config.__file__).parent / "data"
+        self.config_root = Path(config.__file__).parent / "data"
 
     def test_path_for_config(self):
         """path_for_config should give a path to a config file.
-        
+
         The path should be absolute.  It is not checked for existence."""
         # With no arguments (or None or "") we should get the main config
         path = config.path_for_config()
         self.assertTrue(path.is_absolute())
         self.assertEqual(
-                path.relative_to(self.config_root),
-                Path("config.yml")
-                )
+            path.relative_to(self.config_root),
+            Path("config.yml")
+            )
         self.assertTrue(path.exists())
         path2 = config.path_for_config(None)
         self.assertEqual(path, path2)
@@ -45,7 +45,7 @@ class TestConfig(unittest.TestCase):
 
     def test_layer_configs(self):
         """layer_configs should combine the data from a list of config paths.
-        
+
         The later entries take priority over the earlier ones.  Dicts are
         updated recursively, not replaced outright like dict.update does."""
         paths = [config.path_for_config(c) for c in self.configs]
@@ -59,44 +59,44 @@ class TestConfig(unittest.TestCase):
         # No entries gives an empty dict.
         config_obs = config.layer_configs([])
         self.assertEqual(config_obs, {})
-        # Missing entries are skipped. 
+        # Missing entries are skipped.
         config_obs = config.layer_configs([None] + paths + [""])
         self.assertTrue(config_obs["readonly"])
 
     def test_update_tree(self):
         """update_tree should combine dictionaries deeply.
-        
+
         Dicts should be updated recursively, not replaced outright like
         dict.update does."""
         tree_old = {
-                "something": {
-                    "level2": {
-                        "attr_a": 1,
-                        "attr_b": 2
-                        },
-                    "shallow": True
-                    }
+            "something": {
+                "level2": {
+                    "attr_a": 1,
+                    "attr_b": 2
+                    },
+                "shallow": True
                 }
+            }
         tree_new = {
-                "something": {
-                    "level2": {
-                        "attr_b": 4,
-                        "attr_c": 3
-                        }
+            "something": {
+                "level2": {
+                    "attr_b": 4,
+                    "attr_c": 3
                     }
                 }
+            }
         # Here attr_b should be replaced and attr_c added, but attr_a should
         # still be present, too.
         tree_exp = {
-                "something": {
-                    "level2": {
-                        "attr_a": 1,
-                        "attr_b": 4,
-                        "attr_c": 3
-                        },
-                    "shallow": True
-                    }
+            "something": {
+                "level2": {
+                    "attr_a": 1,
+                    "attr_b": 4,
+                    "attr_c": 3
+                    },
+                "shallow": True
                 }
+            }
         tree_obs = config.update_tree(tree_old, tree_new)
         self.assertEqual(tree_obs, tree_exp)
 

--- a/test_umbra/test_config.py
+++ b/test_umbra/test_config.py
@@ -3,8 +3,10 @@
 Tests for config module functions.
 """
 
-from .test_common import *
+import unittest
+from pathlib import Path
 from umbra import config
+import umbra.config
 
 class TestConfig(unittest.TestCase):
 

--- a/test_umbra/test_illumina/test_alignment.py
+++ b/test_umbra/test_illumina/test_alignment.py
@@ -1,11 +1,18 @@
+"""
+Test umbra.illumina.alignment
+
+More specifically, test the Alignment class that represents a specific
+subdirectory of an Illumina run directory on disk.
+"""
+
 import unittest
 import os
 from shutil import move
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from distutils.dir_util import copy_tree
-from .test_common import RUN_IDS, PATH_RUNS
 from umbra.illumina.run import Alignment
+from .test_common import RUN_IDS, PATH_RUNS
 
 class TestAlignment(unittest.TestCase):
     """Test an Alignment in a typical case (MiSeq, paired-end)."""
@@ -13,113 +20,129 @@ class TestAlignment(unittest.TestCase):
     def setUp(self):
         if not hasattr(self, "run_id"):
             self.run_id = RUN_IDS["MiSeq"]
-        self.setUpFiles()
-        self.setUpVars()
-        self.setUpAlignment()
+        self.set_up_files()
+        self.set_up_vars()
+        self.set_up_alignment()
 
-    def setUpVars(self):
+    def set_up_files(self):
+        """Make a full copy of one run to a temp location."""
+        self.tmpdir = TemporaryDirectory()
+        self.paths = {}
+        self.paths["run"] = Path(self.tmpdir.name) / self.run_id
+        copy_tree(str(PATH_RUNS / self.run_id), str(self.paths["run"]))
+
+    def set_up_vars(self):
+        """Initialize expected values for testing."""
         self.num_samples = 35
         self.first_files = [
-                "1086S1-01_S1_L001_R1_001.fastq.gz",
-                "1086S1-01_S1_L001_R2_001.fastq.gz"
-                ]
+            "1086S1-01_S1_L001_R1_001.fastq.gz",
+            "1086S1-01_S1_L001_R2_001.fastq.gz"
+            ]
         self.experiment_exp = "Partials_1_1_18"
-        self.path_al = self.path_run / "Data/Intensities/BaseCalls/Alignment"
-        self.path_sample_sheet = self.path_al / "SampleSheetUsed.csv"
-        self.path_fastq = (self.path_al/ "..").resolve()
-        self.path_checkpoint = self.path_al / "Checkpoint.txt"
+        self.paths["alignment"] = (
+            self.paths["run"] /
+            "Data/Intensities/BaseCalls/Alignment")
+        self.paths["sample_sheet"] = (
+            self.paths["alignment"] /
+            "SampleSheetUsed.csv")
+        self.paths["fastq"] = (self.paths["alignment"]/ "..").resolve()
+        self.paths["checkpoint"] = self.paths["alignment"] / "Checkpoint.txt"
         self.ss_keys_exp = ["Data", "Header", "Reads", "Settings"]
 
-    def setUpFiles(self):
-        # Make a full copy of one run to a temp location
-        self.tmpdir = TemporaryDirectory()
-        self.path_run = Path(self.tmpdir.name) / self.run_id
-        copy_tree(str(PATH_RUNS / self.run_id), str(self.path_run))
-
-    def setUpAlignment(self):
-        self.al = Alignment(self.path_al)
+    def set_up_alignment(self):
+        """Initialize alignment object for testing."""
+        self.alignment = Alignment(self.paths["alignment"])
 
     def tearDown(self):
         self.tmpdir.cleanup()
 
     def test_attrs(self):
         """Test attributes from object creation"""
-        self.assertEqual(self.al.path_sample_sheet, self.path_sample_sheet)
-        self.assertEqual(self.al.path_fastq,        self.path_fastq)
-        self.assertEqual(self.al.path_checkpoint,   self.path_checkpoint)
-        self.assertEqual(sorted(self.al.sample_sheet.keys()), self.ss_keys_exp)
+        self.assertEqual(self.alignment.path_sample_sheet, self.paths["sample_sheet"])
+        self.assertEqual(self.alignment.path_fastq, self.paths["fastq"])
+        self.assertEqual(self.alignment.path_checkpoint, self.paths["checkpoint"])
+        self.assertEqual(sorted(self.alignment.sample_sheet.keys()), self.ss_keys_exp)
 
     def test_index(self):
         """Test that the index within the Run's list of Alignments is correct.
-        
+
         For an Alignment without a Run, there is no index defined.
         """
-        self.assertIsNone(self.al.index)
+        self.assertIsNone(self.alignment.index)
 
     def test_complete(self):
         """Is an Alignment complete?"""
         # An alignment is complete if Checkpoint exists and is 3, is not
         # complete otherwise.
-        self.assertTrue(self.al.complete)
-        os.remove(self.al.path_checkpoint)
-        self.al = Alignment(self.path_al)
-        self.assertFalse(self.al.complete)
+        self.assertTrue(self.alignment.complete)
+        os.remove(self.alignment.path_checkpoint)
+        alignment = Alignment(self.paths["alignment"])
+        self.assertFalse(alignment.complete)
 
     def test_experiment(self):
         """Is the Experiment name available?"""
-        self.assertEqual(self.al.experiment, self.experiment_exp)
+        self.assertEqual(self.alignment.experiment, self.experiment_exp)
 
     def test_sample_numbers(self):
+        """Test for expected number of samples."""
         nums = [i+1 for i in range(self.num_samples)]
-        self.assertEqual(self.al.sample_numbers, nums)
+        self.assertEqual(self.alignment.sample_numbers, nums)
 
     def test_sample_names(self):
-        self.assertEqual(len(self.al.sample_names), self.num_samples)
+        """Test existence (not content, currently) of sample names."""
+        self.assertEqual(len(self.alignment.sample_names), self.num_samples)
 
     def test_samples(self):
-        data = self.al.sample_sheet["Data"]
-        self.assertEqual(self.al.samples, data)
+        """Test for consistency of sample metadata with sample sheet."""
+        data = self.alignment.sample_sheet["Data"]
+        self.assertEqual(self.alignment.samples, data)
 
     def test_sample_files_for_num(self):
         """Test expected sample filenames for one sample number"""
         # This run is paired-end so we should get two read files per sample.
-        filenames_observed = self.al.sample_files_for_num(1)
+        filenames_observed = self.alignment.sample_files_for_num(1)
         self.assertEqual(filenames_observed, self.first_files)
 
     def test_sample_paths_for_num(self):
         """Test expected sample paths for one sample number"""
-        filepaths_exp = [ self.al.path_fastq / fn for fn in self.first_files]
-        filepaths_obs = self.al.sample_paths_for_num(1)
+        aln = self.alignment
+        filepaths_exp = [aln.path_fastq / fn for fn in self.first_files]
+        filepaths_obs = aln.sample_paths_for_num(1)
         self.assertEqual(filepaths_obs, filepaths_exp)
 
     def test_sample_paths(self):
         """Test sample paths by sample name for all samples"""
-        sp = self.al.sample_paths()
+        aln = self.alignment
+        spaths = aln.sample_paths()
         # The keys are sample names
-        self.assertEqual(sorted(sp.keys()), sorted(self.al.sample_names))
+        self.assertEqual(
+            sorted(spaths.keys()),
+            sorted(aln.sample_names))
         # The values are sample paths
-        v = [self.al.sample_paths_for_num(n) for n in self.al.sample_numbers]
-        k = self.al.sample_names
-        sp_exp = {k: v for k,v in zip(k, v)}
-        self.assertEqual(sp, sp_exp)
+        vals = [aln.sample_paths_for_num(n) for n in aln.sample_numbers]
+        keys = aln.sample_names
+        spaths_exp = {k: v for k, v in zip(keys, vals)}
+        self.assertEqual(spaths, spaths_exp)
 
     def test_refresh(self):
         """Does refresh catch completion?"""
         # Starting without a Checkpoint.txt, alignment is marked incomplete.
-        move(str(self.al.path_checkpoint), str(self.path_run))
-        self.al = Alignment(self.path_al)
-        self.assertFalse(self.al.complete)
+        move(str(self.alignment.path_checkpoint), str(self.paths["run"]))
+        alignment = Alignment(self.paths["alignment"])
+        self.assertFalse(alignment.complete)
         # It doesn't update automatically.
-        move(str(self.path_run / "Checkpoint.txt"), str(self.al.path_checkpoint))
-        self.assertFalse(self.al.complete)
+        move(
+            str(self.paths["run"] / "Checkpoint.txt"),
+            str(alignment.path_checkpoint))
+        self.assertFalse(alignment.complete)
         # On refresh, it is now seen as complete.
-        self.al.refresh()
-        self.assertTrue(self.al.complete)
+        alignment.refresh()
+        self.assertTrue(alignment.complete)
 
 
 class TestAlignmentSingleEnded(TestAlignment):
     """Test an Alignment for a non-paired-end Run.
-    
+
     The only thing that should be different here is that the run files will
     only have R1, no R2."""
 
@@ -127,8 +150,8 @@ class TestAlignmentSingleEnded(TestAlignment):
         self.run_id = RUN_IDS["Single"]
         super().setUp()
 
-    def setUpVars(self):
-        super().setUpVars()
+    def set_up_vars(self):
+        super().set_up_vars()
         self.num_samples = 4
         self.first_files = ["GA_S1_L001_R1_001.fastq.gz"]
         self.experiment_exp = "ExperimentSingle"
@@ -140,30 +163,32 @@ class TestAlignmentFilesMissing(TestAlignment):
     def test_sample_paths_for_num(self):
         """Test expected sample paths for one sample number"""
         # By default a missing file throws FileNotFound error.
-        filepaths_exp = [ self.al.path_fastq / fn for fn in self.first_files]
-        move(str(filepaths_exp[1]), str(self.path_al))
+        filepaths_exp = [self.alignment.path_fastq / fn for fn in self.first_files]
+        move(str(filepaths_exp[1]), str(self.paths["alignment"]))
         with self.assertRaises(FileNotFoundError):
-            self.al.sample_paths_for_num(1)
-        # Unless we give strict = False.  The same names are returned but one
+            self.alignment.sample_paths_for_num(1)
+        # Unless we give strict=False.  The same names are returned but one
         # of them doesn't exist.
-        filepaths_obs = self.al.sample_paths_for_num(1, strict = False)
+        filepaths_obs = self.alignment.sample_paths_for_num(1, strict=False)
         self.assertEqual(filepaths_obs, filepaths_exp)
 
     def test_sample_paths(self):
         """Test sample paths by sample name for all samples"""
-        path = self.al.path_fastq / "1086S1-01_S1_L001_R2_001.fastq.gz"
-        move(str(path), str(self.path_al))
+        path = self.alignment.path_fastq / "1086S1-01_S1_L001_R2_001.fastq.gz"
+        move(str(path), str(self.paths["alignment"]))
         with self.assertRaises(FileNotFoundError):
-            sp = self.al.sample_paths()
-        sp = self.al.sample_paths(strict = False)
+            spaths = self.alignment.sample_paths()
+        spaths = self.alignment.sample_paths(strict=False)
         # The keys are sample names
-        self.assertEqual(sorted(sp.keys()), sorted(self.al.sample_names))
+        self.assertEqual(
+            sorted(spaths.keys()),
+            sorted(self.alignment.sample_names))
         # The values are sample paths
-        nums = self.al.sample_numbers
-        v = [self.al.sample_paths_for_num(n, False) for n in nums]
-        k = self.al.sample_names
-        sp_exp = {k: v for k,v in zip(k, v)}
-        self.assertEqual(sp, sp_exp)
+        nums = self.alignment.sample_numbers
+        vals = [self.alignment.sample_paths_for_num(n, False) for n in nums]
+        keys = self.alignment.sample_names
+        spaths_exp = {k: v for k, v in zip(keys, vals)}
+        self.assertEqual(spaths, spaths_exp)
 
 
 class TestAlignmentMiniSeq(TestAlignment):
@@ -173,18 +198,22 @@ class TestAlignmentMiniSeq(TestAlignment):
         self.run_id = RUN_IDS["MiniSeq"]
         super().setUp()
 
-    def setUpVars(self):
+    def set_up_vars(self):
         self.num_samples = 5
         self.first_files = [
-                "TL3833-2-3_S1_L001_R1_001.fastq.gz",
-                "TL3833-2-3_S1_L001_R2_001.fastq.gz"
-                ]
+            "TL3833-2-3_S1_L001_R1_001.fastq.gz",
+            "TL3833-2-3_S1_L001_R2_001.fastq.gz"
+            ]
         self.experiment_exp = "MiniSeqExperiment"
         subdir = "20180103_110937"
-        self.path_al = self.path_run / "Alignment_1"
-        self.path_sample_sheet = self.path_al / subdir / "SampleSheetUsed.csv"
-        self.path_fastq = self.path_al / subdir / "Fastq"
-        self.path_checkpoint = self.path_al / subdir / "Checkpoint.txt"
+        self.paths["alignment"] = (
+            self.paths["run"] / "Alignment_1")
+        self.paths["sample_sheet"] = (
+            self.paths["alignment"] / subdir / "SampleSheetUsed.csv")
+        self.paths["fastq"] = (
+            self.paths["alignment"] / subdir / "Fastq")
+        self.paths["checkpoint"] = (
+            self.paths["alignment"] / subdir / "Checkpoint.txt")
         self.ss_keys_exp = ["Data", "Header", "Reads"]
 
 

--- a/test_umbra/test_illumina/test_alignment.py
+++ b/test_umbra/test_illumina/test_alignment.py
@@ -62,13 +62,13 @@ class TestAlignment(unittest.TestCase):
     def test_attrs(self):
         """Test attributes from object creation"""
         self.assertEqual(
-            self.alignment.path_sample_sheet,
+            self.alignment.paths["sample_sheet"],
             self.expected["paths"]["sample_sheet"])
         self.assertEqual(
-            self.alignment.path_fastq,
+            self.alignment.paths["fastq"],
             self.expected["paths"]["fastq"])
         self.assertEqual(
-            self.alignment.path_checkpoint,
+            self.alignment.paths["checkpoint"],
             self.expected["paths"]["checkpoint"])
         self.assertEqual(sorted(self.alignment.sample_sheet.keys()), self.expected["ss_keys"])
 
@@ -84,7 +84,7 @@ class TestAlignment(unittest.TestCase):
         # An alignment is complete if Checkpoint exists and is 3, is not
         # complete otherwise.
         self.assertTrue(self.alignment.complete)
-        os.remove(self.alignment.path_checkpoint)
+        os.remove(self.alignment.paths["checkpoint"])
         alignment = Alignment(self.paths["alignment"])
         self.assertFalse(alignment.complete)
 
@@ -118,7 +118,7 @@ class TestAlignment(unittest.TestCase):
         """Test expected sample paths for one sample number"""
         aln = self.alignment
         first_files = self.expected["first_files"]
-        filepaths_exp = [aln.path_fastq / fn for fn in first_files]
+        filepaths_exp = [aln.paths["fastq"] / fn for fn in first_files]
         filepaths_obs = aln.sample_paths_for_num(1)
         self.assertEqual(filepaths_obs, filepaths_exp)
 
@@ -139,13 +139,13 @@ class TestAlignment(unittest.TestCase):
     def test_refresh(self):
         """Does refresh catch completion?"""
         # Starting without a Checkpoint.txt, alignment is marked incomplete.
-        move(str(self.alignment.path_checkpoint), str(self.paths["run"]))
+        move(str(self.alignment.paths["checkpoint"]), str(self.paths["run"]))
         alignment = Alignment(self.paths["alignment"])
         self.assertFalse(alignment.complete)
         # It doesn't update automatically.
         move(
             str(self.paths["run"] / "Checkpoint.txt"),
-            str(alignment.path_checkpoint))
+            str(alignment.paths["checkpoint"]))
         self.assertFalse(alignment.complete)
         # On refresh, it is now seen as complete.
         alignment.refresh()
@@ -176,7 +176,7 @@ class TestAlignmentFilesMissing(TestAlignment):
         """Test expected sample paths for one sample number"""
         # By default a missing file throws FileNotFound error.
         first_files = self.expected["first_files"]
-        filepaths_exp = [self.alignment.path_fastq / fn for fn in first_files]
+        filepaths_exp = [self.alignment.paths["fastq"] / fn for fn in first_files]
         move(str(filepaths_exp[1]), str(self.paths["alignment"]))
         with self.assertRaises(FileNotFoundError):
             self.alignment.sample_paths_for_num(1)
@@ -187,7 +187,7 @@ class TestAlignmentFilesMissing(TestAlignment):
 
     def test_sample_paths(self):
         """Test sample paths by sample name for all samples"""
-        path = self.alignment.path_fastq / "1086S1-01_S1_L001_R2_001.fastq.gz"
+        path = self.alignment.paths["fastq"] / "1086S1-01_S1_L001_R2_001.fastq.gz"
         move(str(path), str(self.paths["alignment"]))
         with self.assertRaises(FileNotFoundError):
             spaths = self.alignment.sample_paths()

--- a/test_umbra/test_illumina/test_alignment.py
+++ b/test_umbra/test_illumina/test_alignment.py
@@ -1,4 +1,11 @@
-from .test_common import *
+import unittest
+import os
+from shutil import move
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from distutils.dir_util import copy_tree
+from .test_common import RUN_IDS, PATH_RUNS
+from umbra.illumina.run import Alignment
 
 class TestAlignment(unittest.TestCase):
     """Test an Alignment in a typical case (MiSeq, paired-end)."""

--- a/test_umbra/test_illumina/test_common.py
+++ b/test_umbra/test_illumina/test_common.py
@@ -1,11 +1,4 @@
-import warnings
-import datetime
-from tempfile import TemporaryDirectory
-from shutil import move
-import os
-from ..test_common import *
-
-from umbra.illumina.run import Run, Alignment
+from ..test_common import PATH_DATA
 
 RUN_IDS = {
         "MiSeq":       "180101_M00000_0000_000000000-XXXXX",

--- a/test_umbra/test_illumina/test_common.py
+++ b/test_umbra/test_illumina/test_common.py
@@ -1,3 +1,7 @@
+"""
+Helpers for other test modules.
+"""
+
 from ..test_common import PATH_DATA
 
 RUN_IDS = {

--- a/test_umbra/test_illumina/test_run.py
+++ b/test_umbra/test_illumina/test_run.py
@@ -70,7 +70,7 @@ class TestRun(unittest.TestCase):
     def check_refresh_alignments(self):
         """Test refreshing run Alignment directories from files on disk."""
         orig_als = self.run.alignments
-        path_checkpoint = self.run.alignments[0].path_checkpoint
+        path_checkpoint = self.run.alignments[0].paths["checkpoint"]
         move(str(path_checkpoint), str(self.path_run / "tmp.txt"))
         self.run = Run(self.path_run)
         self.assertEqual(len(self.run.alignments), len(orig_als))

--- a/test_umbra/test_illumina/test_run.py
+++ b/test_umbra/test_illumina/test_run.py
@@ -1,3 +1,10 @@
+"""
+Test umbra.illumina.run
+
+More specifically, test the Run class that represents an Illumina run directory
+on disk.
+"""
+
 import unittest
 import time
 import datetime
@@ -10,7 +17,10 @@ from umbra.illumina.run import Run
 from .test_common import RUN_IDS, PATH_RUNS
 
 class TestRun(unittest.TestCase):
-    """Base test case for a Run."""
+    """Base test case for a Run.
+
+    This is built around a mock MiSeq run directory.
+    """
 
     def setUp(self):
         self.tmpdir = TemporaryDirectory()
@@ -27,6 +37,7 @@ class TestRun(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_attrs(self):
+        """Test various Run properties."""
         # RunInfo.xml
         # Check the Run ID.
         id_obs = self.run.run_info.find("Run").attrib["Id"]
@@ -43,6 +54,7 @@ class TestRun(unittest.TestCase):
         self.assertEqual(self.t2_exp, t2_obs)
 
     def check_refresh_run(self):
+        """Test refreshing run state from files on disk."""
         # Starting without a RTAComplete.txt, run is marked incomplete.
         move(str(self.path_run / "RTAComplete.txt"), str(self.path_run / "tmp.txt"))
         self.run = Run(self.path_run)
@@ -56,6 +68,7 @@ class TestRun(unittest.TestCase):
         self.assertTrue(self.run.complete)
 
     def check_refresh_alignments(self):
+        """Test refreshing run Alignment directories from files on disk."""
         orig_als = self.run.alignments
         path_checkpoint = self.run.alignments[0].path_checkpoint
         move(str(path_checkpoint), str(self.path_run / "tmp.txt"))
@@ -82,6 +95,7 @@ class TestRun(unittest.TestCase):
         self.check_refresh_alignments() # 2: refresh existing alignments
 
     def test_run_id(self):
+        """Test the run ID property."""
         self.assertEqual(self.id_exp, self.run.run_id)
 
 
@@ -101,6 +115,13 @@ class TestRunSingle(TestRun):
 
 
 class TestRunMiniSeq(TestRun):
+    """Like TestRun, but for a MiniSeq run.
+
+    Nothing should really change in how the information is presented, just a
+    few details that are different for this particular run.  The class should
+    abstract away the actual differences in run directory layout between the
+    different sequencer model.s
+    """
 
     def setUp(self):
         self.tmpdir = TemporaryDirectory()
@@ -129,45 +150,47 @@ class TestRunMisnamed(TestRun):
         self.t2_exp = "2018-01-02T06:48:32.608024-04:00"
 
     def test_init(self):
-        with warnings.catch_warnings(record=True) as w:
+        """Test that we get the expected warning during Run initialization."""
+        with warnings.catch_warnings(record=True) as warn_list:
             warnings.simplefilter("always")
             Run(self.path_run, strict=True)
-            self.assertEqual(1, len(w))
-        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(1, len(warn_list))
+        with warnings.catch_warnings(record=True) as warn_list:
             warnings.simplefilter("always")
             Run(self.path_run)
-            self.assertEqual(0, len(w))
-        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(0, len(warn_list))
+        with warnings.catch_warnings(record=True) as warn_list:
             warnings.simplefilter("always")
             Run(self.path_run, strict=False)
-            self.assertEqual(0, len(w))
+            self.assertEqual(0, len(warn_list))
 
 
 class TestRunInvalid(unittest.TestCase):
     """Test case for a directory that is not an Illumina run."""
 
     def test_init(self):
+        """Test that Run initialization handles invalid an run directory."""
         path = PATH_RUNS / RUN_IDS["not a run"]
         with self.assertRaises(ValueError):
             Run(path)
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn_list:
             warnings.simplefilter("always")
-            run = Run(path, strict = False)
-            self.assertEqual(1, len(w))
+            run = Run(path, strict=False)
+            self.assertEqual(1, len(warn_list))
             self.assertTrue(run.invalid)
         path = PATH_RUNS / RUN_IDS["nonexistent"]
         with self.assertRaises(ValueError):
             Run(path)
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn_list:
             warnings.simplefilter("always")
-            run = Run(path, strict = False)
-            self.assertEqual(1, len(w))
+            run = Run(path, strict=False)
+            self.assertEqual(1, len(warn_list))
             self.assertTrue(run.invalid)
 
 
 class TestRunMinAlignmentAge(TestRun):
     """Test case for a Run set to ignore too-new alignment directories.
-    
+
     This should not warn about empty alignment directories if they're newer (by
     ctime) than a certain age."""
 
@@ -181,12 +204,12 @@ class TestRunMinAlignmentAge(TestRun):
         # alignment directories.  We'll use a one-second setting for this test,
         # and will touch the directory to reset the ctime.
         self.run.alignments[0].path.touch()
-        with self.assertLogs(level = "DEBUG") as cm:
-            self.run = Run(self.path_run, min_alignment_dir_age = 1)
+        with self.assertLogs(level="DEBUG") as log_context:
+            self.run = Run(self.path_run, min_alignment_dir_age=1)
         # That alignment shouldn't have been added to the list yet.  No
         # warnings should have been generated, just a debug log message about
         # the skip.
-        self.assertEqual(len(cm.output), 1)
+        self.assertEqual(len(log_context.output), 1)
         self.assertEqual(len(self.run.alignments), len(orig_als)-1)
         # After enough time has passed it should be loaded.
         time.sleep(1.1)

--- a/test_umbra/test_illumina/test_run.py
+++ b/test_umbra/test_illumina/test_run.py
@@ -1,5 +1,13 @@
-from .test_common import *
+import unittest
 import time
+import datetime
+import warnings
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from distutils.dir_util import copy_tree
+from shutil import move
+from umbra.illumina.run import Run
+from .test_common import RUN_IDS, PATH_RUNS
 
 class TestRun(unittest.TestCase):
     """Base test case for a Run."""

--- a/test_umbra/test_illumina/test_util.py
+++ b/test_umbra/test_illumina/test_util.py
@@ -1,12 +1,14 @@
-from .test_common import *
-from umbra.illumina import util
-
 """
 Tests for illumina.util helper functions.
 
 These currently just test load_csv against the complexities that come up with
 loading real-life CSV files.  (There are more than I ever would have expected.)
 """
+
+import unittest
+import csv
+from umbra.illumina import util
+from .test_common import PATH_OTHER
 
 class TestLoadCSV(unittest.TestCase):
     """Base test case for a CSV file."""
@@ -43,7 +45,7 @@ class TestLoadCSVWindows(TestLoadCSV):
 
 class TestLoadCSVMac(TestLoadCSV):
     """Test CSV loading with \\r line endings.
-    
+
     Yes this does still come up (CSV export in Microsoft Office on Mac OS)."""
 
     def setUp(self):
@@ -75,7 +77,7 @@ class TestLoadCSVUTF8BOM(TestLoadCSV):
 
 class TestLoadCSVMissing(TestLoadCSV):
     """Test CSV loading for a nonexistent file.
-    
+
     Any attempt should raise FileNotFoundError."""
 
     def setUp(self):

--- a/test_umbra/test_mailer.py
+++ b/test_umbra/test_mailer.py
@@ -5,10 +5,11 @@ Tests for Mailer objects.
 This uses a temporary SMTP server to receive and check "sent" messages.
 """
 
-from .test_common import *
+import unittest
 import pwd
 import socket
 import os
+import re
 import smtpd
 import smtplib
 import asyncore

--- a/test_umbra/test_mailer.py
+++ b/test_umbra/test_mailer.py
@@ -23,14 +23,40 @@ class StubSMTP(smtpd.SMTPServer):
 
     @property
     def message_parsed(self):
+        """Received message parsed into a dict."""
         data = self.message.decode("UTF-8")
-        return(self._parse(data))
+        return StubSMTP.parse(data)
 
     @property
     def message_pretty(self):
-        return(self._prettify(self.message_parsed))
+        """Received message pretty-printed as a string."""
+        return self._prettify(self.message_parsed)
 
-    def _parse_header(self, header):
+    @staticmethod
+    def parse(data):
+        """Parse a message section from a string into a dict.
+
+        This calls itself recursively on multipart meessages, creating a nested
+        dictionary structure corresponding to the message structure.
+        """
+        # locate double-newline between header and body of message
+        i = data.find('\n\n')
+        # split
+        header = data[0:i]
+        body = data[(i+2):len(data)]
+        header = StubSMTP.parse_header(header)
+        if "multipart" in header.get("Content-Type", ""):
+            msg = re.search('boundary="(.*)"', header["Content-Type"])
+            boundary = msg.group(1)
+            body = re.split("\n?--"+boundary+"(?:--)?\n?", body)
+            body = [StubSMTP.parse(b) for b in body if b]
+        else:
+            body = [body]
+        return {"header": header, "body": body}
+
+    @staticmethod
+    def parse_header(header):
+        """Parse the header from message text into a simple dictionary."""
         # unwrap
         header = re.sub("\n ", " ", header)
         # split keys/vals
@@ -39,23 +65,7 @@ class StubSMTP(smtpd.SMTPServer):
         header = [h.split(":") for h in header]
         header = [[h[0], h[1].lstrip()] for h in header]
         header = {h[0]: h[1] for h in header}
-        return(header)
-
-    def _parse(self, data):
-        # locate double-newline between header and body of message
-        i = data.find('\n\n')
-        # split
-        header = data[0:i]
-        body = data[(i+2):len(data)]
-        header = self._parse_header(header)
-        if "multipart" in header.get("Content-Type", ""):
-            m = re.search('boundary="(.*)"', header["Content-Type"])
-            boundary = m.group(1)
-            body = re.split("\n?--"+boundary+"(?:--)?\n?", body)
-            body = [self._parse(b) for b in body if b]
-        else:
-            body = [body]
-        return({"header": header, "body": body})
+        return header
 
     def _prettify(self, data=None, indent=""):
         output = ""
@@ -65,13 +75,14 @@ class StubSMTP(smtpd.SMTPServer):
             for key in data["header"]:
                 output += "%s%s: %s\n" % (indent, key, data["header"][key])
             for chunk in data["body"]:
-                    output += self._prettify(chunk, indent + "  ")
+                output += self._prettify(chunk, indent + "  ")
         except TypeError:
             data = "\n".join([indent + c for c in data.split("\n")])
             output += data + "\n"
-        return(output)
+        return output
 
     def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
+        # pylint: disable=attribute-defined-outside-init
         self.message = data
         self.rcpttos = rcpttos
 
@@ -81,18 +92,19 @@ class TestMailer(unittest.TestCase):
     """ Test Mailer with a typical use case."""
 
     def setUp(self):
-        self.setUpSMTP()
+        self.set_up_smtp()
         self.mailer = Mailer(self.host, self.port)
-        self.setUpVars()
+        self.set_up_vars()
 
-    def setUpVars(self):
+    def set_up_vars(self):
+        """Initialize expected values for testing."""
         self.mail_args = {
-                "from_addr": "user1@example.com",
-                "to_addrs": "user2@example.com",
-                "subject": "Hi There",
-                "msg_body": "A few words\nin a plaintext message",
-                "msg_html": "<b><i>Ooooh HTML</i></b>"
-                }
+            "from_addr": "user1@example.com",
+            "to_addrs": "user2@example.com",
+            "subject": "Hi There",
+            "msg_body": "A few words\nin a plaintext message",
+            "msg_html": "<b><i>Ooooh HTML</i></b>"
+            }
         self.expected = dict(self.mail_args)
         self.expected["to_addrs"] = [self.expected["to_addrs"]]
         # The message was actually sent, right?  In certain situations we can
@@ -108,72 +120,81 @@ class TestMailer(unittest.TestCase):
         if hasattr(self, "thread"):
             self.thread.join()
 
-    def setUpSMTP(self):
+    def set_up_smtp(self):
+        """Initialize fake SMTP server to receive messages."""
         self.host = "127.0.0.1"
         # select an arbitrary open port for the temporary SMTP server.
         self.port = 0
         self.smtpd = StubSMTP((self.host, self.port), (None, None))
         self.port = self.smtpd.socket.getsockname()[1]
         kwargs = {"timeout": 0}
-        self.thread = threading.Thread(target=asyncore.loop,
-                kwargs=kwargs,
-                daemon=True)
+        self.thread = threading.Thread(
+            target=asyncore.loop,
+            kwargs=kwargs,
+            daemon=True)
         self.thread.start()
-    
+
     def check_mail(self):
+        """Compare SMTPD-received message to expected message."""
         # Test recipients
         # This should be a list of the To addresses and CC addresses (if
         # present)
         exp = self.expected
-        to = exp.get("to_addrs", [])
-        cc = exp.get("cc_addrs", [])
+        to_addrs = exp.get("to_addrs", [])
+        cc_addrs = exp.get("cc_addrs", [])
+        msg = None
         # If it looks like no message was received, just return here.  But fail
         # if that was unexpected.
         if not hasattr(self.smtpd, "rcpttos"):
             if self.exp_sent:
                 self.fail("SMTPD did not receive a message")
-            return
-        recipients = to + cc
+            return msg
+        recipients = to_addrs + cc_addrs
         self.assertEqual(self.smtpd.rcpttos, recipients)
         # Test message attributes
-        m = self.smtpd.message_parsed
-        self.assertEqual(m["header"]["Subject"], exp["subject"])
-        self.assertEqual(m["header"]["From"],    exp["from_addr"])
-        if to:
-            self.assertEqual(m["header"].get("To"), ", ".join(to))
-        if cc:
-            self.assertEqual(m["header"].get("CC"), ", ".join(cc))
+        msg = self.smtpd.message_parsed
+        self.assertEqual(msg["header"]["Subject"], exp["subject"])
+        self.assertEqual(msg["header"]["From"], exp["from_addr"])
+        if to_addrs:
+            self.assertEqual(msg["header"].get("To"), ", ".join(to_addrs))
+        if cc_addrs:
+            self.assertEqual(msg["header"].get("CC"), ", ".join(cc_addrs))
         if "msg_html" in self.mail_args:
-            self.assertEqual(m["body"][0]["body"][0], exp["msg_body"])
-            self.assertEqual(m["body"][1]["body"][0], exp["msg_html"])
+            self.assertEqual(msg["body"][0]["body"][0], exp["msg_body"])
+            self.assertEqual(msg["body"][1]["body"][0], exp["msg_html"])
         else:
-            self.assertEqual(m["body"][0], exp["msg_body"])
-            self.assertEqual(len(m["body"]), 1)
-        return(m)
+            self.assertEqual(msg["body"][0], exp["msg_body"])
+            self.assertEqual(len(msg["body"]), 1)
+        return msg
 
     def test_mail(self):
+        """Test sending a message.
+
+        If self.exp_sent is True, the test will expect that a message was
+        successfully sent.  Otherwise an error is expected to have been logged.
+        """
         failure = None
-        m = None
+        message = None
         try:
             if self.exp_sent:
                 self.mailer.mail(**self.mail_args)
             else:
                 # There should be a complaint in this case
-                with self.assertLogs(level = "ERROR") as cm:
+                with self.assertLogs(level="ERROR") as logging_context:
                     self.mailer.mail(**self.mail_args)
-                self.assertEqual(len(cm.output), 1)
-            m = self.check_mail()
+                self.assertEqual(len(logging_context.output), 1)
+            message = self.check_mail()
         except smtplib.SMTPException:
             failure = "SMTP Failure"
         if failure:
             self.fail(failure)
-        return(m)
+        return message
 
 
 class TestMailerDefaultFrom(TestMailer):
 
     """Test Mailer without specifying the from_addr.
-    
+
     In this case the local username and hostname will be used to construct a
     From address."""
 
@@ -188,7 +209,7 @@ class TestMailerDefaultFrom(TestMailer):
 class TestMailerNoHTML(TestMailer):
 
     """Test Mailer with a plaintext message only, no HTML.
-    
+
     The message in this case should not be multipart."""
 
     def setUp(self):
@@ -199,7 +220,7 @@ class TestMailerNoHTML(TestMailer):
 class TestMailerMultipleRecipients(TestMailer):
 
     """ Test Mailer giving a list of to_addrs.
-    
+
     If a list is given, it should show up as a single header entry in the
     received message."""
 
@@ -214,11 +235,11 @@ class TestMailerCCAddrs(TestMailer):
     """ Test Mailer giving a single address for cc_addrs."""
 
     def setUp(self):
-        self.setUpSMTP()
-        cc = "admin@example.com"
-        self.mailer = Mailer(self.host, self.port, cc_addrs=cc)
-        self.setUpVars()
-        self.expected["cc_addrs"] = [cc]
+        self.set_up_smtp()
+        cc_addrs = "admin@example.com"
+        self.mailer = Mailer(self.host, self.port, cc_addrs=cc_addrs)
+        self.set_up_vars()
+        self.expected["cc_addrs"] = [cc_addrs]
 
 
 class TestMailerCCAddrsMulti(TestMailer):
@@ -226,16 +247,16 @@ class TestMailerCCAddrsMulti(TestMailer):
     """ Test Mailer giving multiple addresses for cc_addrs."""
 
     def setUp(self):
-        self.setUpSMTP()
-        cc = ["admin@example.com", "office@example.com"]
-        self.mailer = Mailer(self.host, self.port, cc_addrs=cc)
-        self.setUpVars()
-        self.expected["cc_addrs"] = cc
+        self.set_up_smtp()
+        cc_addrs = ["admin@example.com", "office@example.com"]
+        self.mailer = Mailer(self.host, self.port, cc_addrs=cc_addrs)
+        self.set_up_vars()
+        self.expected["cc_addrs"] = cc_addrs
 
 
 class TestMailerNoTo(TestMailer):
     """ Test Mailer giving empty to_addrs.
-    
+
     In this case there are no recipients at all, and the message is created but
     not sent.  An error should be logged."""
 
@@ -248,26 +269,26 @@ class TestMailerNoTo(TestMailer):
 
 class TestMailerOnlyCC(TestMailer):
     """ Test Mailer giving empty to_addrs but with cc_addrs.
-    
+
     In this case there are still technically recipients but only CC addresses.
     This could come up if the mailer is configured for CC but a particular
     message has no specific recipients.  The message should be sent without a
     "To:" field and with a warning logged."""
 
     def setUp(self):
-        self.setUpSMTP()
-        cc = "admin@example.com"
-        self.mailer = Mailer(self.host, self.port, cc_addrs=cc)
-        self.setUpVars()
+        self.set_up_smtp()
+        cc_addrs = "admin@example.com"
+        self.mailer = Mailer(self.host, self.port, cc_addrs=cc_addrs)
+        self.set_up_vars()
         self.mail_args["to_addrs"] = []
         self.expected["to_addrs"] = []
-        self.expected["cc_addrs"] = [cc]
+        self.expected["cc_addrs"] = [cc_addrs]
 
     def test_mail(self):
         # There should be a complaint about the lack of to_addrs
-        with self.assertLogs(level = "WARNING") as cm:
+        with self.assertLogs(level="WARNING") as logging_context:
             self.mailer.mail(**self.mail_args)
-        self.assertEqual(len(cm.output), 1)
+        self.assertEqual(len(logging_context.output), 1)
         self.check_mail()
 
 
@@ -276,15 +297,17 @@ class TestMailerReplyTo(TestMailer):
     """ Test Mailer giving a Reply-To address."""
 
     def setUp(self):
-        self.setUpSMTP()
+        self.set_up_smtp()
         reply_to = "technician@example.com"
         self.mailer = Mailer(self.host, self.port, reply_to=reply_to)
-        self.setUpVars()
+        self.set_up_vars()
         self.expected["reply_to"] = reply_to
 
     def test_mail(self):
-        m = super().test_mail()
-        self.assertEqual(m["header"].get("Reply-To"), self.expected["reply_to"])
+        message = super().test_mail()
+        self.assertEqual(
+            message["header"].get("Reply-To"),
+            self.expected["reply_to"])
 
 
 if __name__ == '__main__':

--- a/test_umbra/test_processor.py
+++ b/test_umbra/test_processor.py
@@ -478,7 +478,6 @@ class TestIlluminaProcessorFailure(TestIlluminaProcessor):
 
     def test_refresh(self):
         """Test that project failure during refresh is logged as expected."""
-        self.proj_str = "2018-01-01-Something_Else-Someone-Jesse"
         # On refresh, the processing failure should be caught and filed as a
         # log message.
         self.proc.start()

--- a/test_umbra/test_processor.py
+++ b/test_umbra/test_processor.py
@@ -7,13 +7,20 @@ correctly, dispatches processing to appropriate ProjectData objects, and
 coordinates simultaneous processing between multiple projects.
 """
 
-from .test_common import *
+import unittest
 import copy
 import io
+import re
 import warnings
 import threading
+import logging
+from pathlib import Path
+from distutils.dir_util import copy_tree, remove_tree, mkpath
+from distutils.file_util import copy_file
+from tempfile import TemporaryDirectory
 from umbra.processor import IlluminaProcessor
 from umbra.project import ProjectData
+from .test_common import TestBase, CONFIG, md5
 
 class TestIlluminaProcessor(TestBase):
     """Main tests for IlluminaProcessor."""

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -21,7 +21,7 @@ import threading
 import logging
 from pathlib import Path
 import yaml
-from umbra import (illumina,  util)
+from umbra import (illumina, util)
 from umbra.illumina.run import Run
 from umbra.project import (ProjectData, ProjectError)
 from .test_common import TestBase, md5
@@ -36,46 +36,53 @@ class TestProjectData(TestBase):
 
     def setUp(self):
         self.setUpTmpdir()
+        # pylint: disable=invalid-name
+        # (don't blame me, pylint, I didn't make unittest)
         self.maxDiff = None
-        # TODO rename this!  TestCase already has a "run" attribute.
-        self.run = Run(self.path_runs / "180101_M00000_0000_000000000-XXXXX")
-        self.alignment = self.run.alignments[0]
-        self.projs = ProjectData.from_alignment(self.alignment,
-                self.path_exp,
-                self.path_status,
-                self.path_proc,
-                self.path_pack,
-                self.uploader,
-                self.mailer)
+        self.runobj = Run(self.path_runs / "180101_M00000_0000_000000000-XXXXX")
+        self.alignment = self.runobj.alignments[0]
+        self.projs = ProjectData.from_alignment(
+            self.alignment,
+            self.path_exp,
+            self.path_status,
+            self.path_proc,
+            self.path_pack,
+            self.uploader,
+            self.mailer)
         # switch to dictionary to make these easier to work with
         self.projs = {p.name: p for p in self.projs}
         self.exp_path = str(self.path_exp / "Partials_1_1_18" / "metadata.csv")
         # Make sure we have what we expect before the real tests
-        self.assertEqual(sorted(self.projs.keys()),
-                ["STR", "Something Else"])
+        self.assertEqual(
+            sorted(self.projs.keys()),
+            ["STR", "Something Else"])
 
     def test_attrs(self):
-        s = self.path_status / self.run.run_id / "0"
+        """Test various ProjectData properties."""
+        path_stat = self.path_status / self.runobj.run_id / "0"
         self.assertEqual(self.projs["STR"].name, "STR")
         self.assertEqual(self.projs["STR"].alignment, self.alignment)
-        self.assertEqual(self.projs["STR"].path, s / "STR.yml")
+        self.assertEqual(self.projs["STR"].path, path_stat / "STR.yml")
         self.assertEqual(self.projs["Something Else"].name, "Something Else")
         self.assertEqual(self.projs["Something Else"].alignment, self.alignment)
-        self.assertEqual(self.projs["Something Else"].path, s / "Something_Else.yml")
+        self.assertEqual(
+            self.projs["Something Else"].path,
+            path_stat / "Something_Else.yml")
 
     def test_work_dir(self):
+        """Test the work_dir property string."""
         # make sure it gives "date-project-names"
         # test any edge cases that may come up for those components
         works = {
-                # The date stamp is by completion date of the alignment, not
-                # start date of the run (i.e., the date encoded in the Run ID).
-                "STR": "2018-01-01-STR-Jesse",
-                # The names are organized in the order presented in the
-                # experiment metadata spreadsheet.  Any non-alphanumeric
-                # characters are converted to _.
-                "Something Else": "2018-01-01-Something_Else-Someone-Jesse"
-                }
-        for key in works.keys():
+            # The date stamp is by completion date of the alignment, not
+            # start date of the run (i.e., the date encoded in the Run ID).
+            "STR": "2018-01-01-STR-Jesse",
+            # The names are organized in the order presented in the
+            # experiment metadata spreadsheet.  Any non-alphanumeric
+            # characters are converted to _.
+            "Something Else": "2018-01-01-Something_Else-Someone-Jesse"
+            }
+        for key in works:
             self.assertEqual(works[key], self.projs[key].work_dir)
 
     def test_metadata(self):
@@ -84,43 +91,43 @@ class TestProjectData(TestBase):
         These are edging toward private attributes but it's easier here to just
         check them all in one go, at least until that's more cleaned up."""
 
-        md = {}
-        md["status"] = "none"
-        md["run_info"] = {"path": str(self.run.path)}
-        md["sample_paths"] = {}
-        md["alignment_info"] = {"path": str(self.alignment.path)}
-        md["run_info"]["path"] = str(self.alignment.run.path)
+        mdata = {}
+        mdata["status"] = "none"
+        mdata["run_info"] = {"path": str(self.runobj.path)}
+        mdata["sample_paths"] = {}
+        mdata["alignment_info"] = {"path": str(self.alignment.path)}
+        mdata["run_info"]["path"] = str(self.alignment.run.path)
 
-        md_str = dict(md)
-        md_se = dict(md)
+        md_str = dict(mdata)
+        md_se = dict(mdata)
 
         exp_info_str = {
-                "name": "Partials_1_1_18",
-                "sample_names": ["1086S1_01", "1086S1_02"],
-                "tasks": ['trim'],
-                "contacts": {'Jesse': 'ancon@upenn.edu'},
-                "path": self.exp_path
-                }
+            "name": "Partials_1_1_18",
+            "sample_names": ["1086S1_01", "1086S1_02"],
+            "tasks": ['trim'],
+            "contacts": {'Jesse': 'ancon@upenn.edu'},
+            "path": self.exp_path
+            }
         exp_info_se = {
-                "name": "Partials_1_1_18",
-                "sample_names": ["1086S1_03", "1086S1_04"],
-                "tasks": [],
-                "contacts": {
-                    "Someone": "person@gmail.com",
-                    "Jesse Connell": "ancon@upenn.edu"
-                    },
-                "path": self.exp_path
-                }
+            "name": "Partials_1_1_18",
+            "sample_names": ["1086S1_03", "1086S1_04"],
+            "tasks": [],
+            "contacts": {
+                "Someone": "person@gmail.com",
+                "Jesse Connell": "ancon@upenn.edu"
+                },
+            "path": self.exp_path
+            }
         ts_str = {
-                "pending": ['trim', 'metadata', 'package', 'upload', 'email'],
-                "current": "",
-                "completed": []
-                }
+            "pending": ['trim', 'metadata', 'package', 'upload', 'email'],
+            "current": "",
+            "completed": []
+            }
         ts_se = {
-                "pending": ['copy', 'metadata', 'package', 'upload', 'email'],
-                "current": "",
-                "completed": []
-                }
+            "pending": ['copy', 'metadata', 'package', 'upload', 'email'],
+            "current": "",
+            "completed": []
+            }
 
         md_str["experiment_info"] = exp_info_str
         md_se["experiment_info"] = exp_info_se
@@ -132,30 +139,32 @@ class TestProjectData(TestBase):
         md_se["work_dir"] = "2018-01-01-Something_Else-Someone-Jesse"
         md_str["work_dir"] = "2018-01-01-STR-Jesse"
 
-        fq = self.path_runs/"180101_M00000_0000_000000000-XXXXX/Data/Intensities/BaseCalls"
+        fastq = self.path_runs/"180101_M00000_0000_000000000-XXXXX/Data/Intensities/BaseCalls"
         fps = {
-                "1086S1_01": [str(fq/"1086S1-01_S1_L001_R1_001.fastq.gz"),
-                              str(fq/"1086S1-01_S1_L001_R2_001.fastq.gz")],
-                "1086S1_02": [str(fq/"1086S1-02_S2_L001_R1_001.fastq.gz"),
-                              str(fq/"1086S1-02_S2_L001_R2_001.fastq.gz")]
-                }
+            "1086S1_01": [str(fastq/"1086S1-01_S1_L001_R1_001.fastq.gz"),
+                          str(fastq/"1086S1-01_S1_L001_R2_001.fastq.gz")],
+            "1086S1_02": [str(fastq/"1086S1-02_S2_L001_R1_001.fastq.gz"),
+                          str(fastq/"1086S1-02_S2_L001_R2_001.fastq.gz")]
+            }
         md_str["sample_paths"] = fps
         fps = {
-                "1086S1_03": [str(fq/"1086S1-03_S3_L001_R1_001.fastq.gz"),
-                              str(fq/"1086S1-03_S3_L001_R2_001.fastq.gz")],
-                "1086S1_04": [str(fq/"1086S1-04_S4_L001_R1_001.fastq.gz"),
-                              str(fq/"1086S1-04_S4_L001_R2_001.fastq.gz")]
-                }
+            "1086S1_03": [str(fastq/"1086S1-03_S3_L001_R1_001.fastq.gz"),
+                          str(fastq/"1086S1-03_S3_L001_R2_001.fastq.gz")],
+            "1086S1_04": [str(fastq/"1086S1-04_S4_L001_R1_001.fastq.gz"),
+                          str(fastq/"1086S1-04_S4_L001_R2_001.fastq.gz")]
+            }
         md_se["sample_paths"] = fps
 
         self.assertEqual(self.projs["STR"]._metadata, md_str)
         self.assertEqual(self.projs["Something Else"]._metadata, md_se)
 
     def test_readonly(self):
+        """Test the readonly property."""
         self.assertTrue(self.projs["STR"].readonly)
         self.assertFalse(self.projs["Something Else"].readonly)
 
     def test_status(self):
+        """Test the status property."""
         # Is the status what we expect from the initial metadata on disk?
         self.assertEqual(self.projs["STR"].status, "complete")
         self.assertEqual(self.projs["Something Else"].status, "none")
@@ -164,25 +173,26 @@ class TestProjectData(TestBase):
             self.projs["STR"].status = "invalid status"
         # is the setter magically keeping the data on disk up to date?
         self.projs["Something Else"].status = "processing"
-        with open(self.projs["Something Else"].path) as f:
+        with open(self.projs["Something Else"].path) as f_in:
             # https://stackoverflow.com/a/1640777
             with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",category=DeprecationWarning)
-                data = yaml.safe_load(f)
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                data = yaml.safe_load(f_in)
             self.assertEqual(data["status"], "processing")
 
     def test_process(self):
-        # test processing all tasks
-        # make sure exceptions are logged to metadata, too.
-        # so far we have STR marked as complete, and Something Else with no
-        # config yet.
-        # A read-only ProjectData (including previously-complete ones) cannot
-        # be re-processed.
+        """Test the process method to actually run all tasks.
+
+        Make sure exceptions are logged to metadata, too.  So far we have STR
+        marked as complete, and Something Else with no config yet.  A read-only
+        ProjectData (including previously-complete ones) cannot be
+        re-processed.
+        """
         with self.assertRaises(ProjectError):
             self.projs["STR"].process()
-        p = self.projs["Something Else"]
-        p.process()
-        self.assertEqual(p.status, "complete")
+        proj = self.projs["Something Else"]
+        proj.process()
+        self.assertEqual(proj.status, "complete")
 
 
 # Single-task ProjectData tests.
@@ -197,18 +207,20 @@ class TestProjectDataOneTask(TestBase):
     def setUp(self):
         self.setUpTmpdir()
         self.setUpVars()
-        self.setUpRun()
+        self.set_up_run()
         # modify project spreadsheet, then create ProjectData
         self.write_test_experiment()
         # Readymade hook for any extra stuff for sub-classes
-        if "setUpPreProject" in dir(self):
-            self.setUpPreProject()
-        self.setUpProj()
+        if "set_up_pre_project" in dir(self):
+            # pylint: disable=no-member
+            self.set_up_pre_project()
+        self.set_up_proj()
 
     def setUpVars(self):
         super().setUpVars()
         if not hasattr(self, "task"):
             self.task = "noop"
+        # pylint: disable=invalid-name
         self.maxDiff = None
         # Expected and shared attributes
         self.sample_names = ["1086S1_01", "1086S1_02", "1086S1_03", "1086S1_04"]
@@ -231,68 +243,76 @@ class TestProjectDataOneTask(TestBase):
         if not hasattr(self, "work_dir_exp"):
             self.work_dir_exp = "2018-01-01-TestProject-Name"
 
-    def setUpRun(self):
-        self.run = Run(self.path_runs / self.rundir)
-        self.alignment = self.run.alignments[0]
+    def set_up_run(self):
+        """Set up run object to use for ProjectData tested."""
+        self.runobj = Run(self.path_runs / self.rundir)
+        self.alignment = self.runobj.alignments[0]
 
     def write_test_experiment(self):
-        fieldnames = ["Sample_Name","Project","Contacts","Tasks"]
+        """Helper to create an experiment metadata spreadsheet."""
+        fieldnames = ["Sample_Name", "Project", "Contacts", "Tasks"]
         exp_row = lambda sample_name: {
-                "Sample_Name": sample_name,
-                "Project": self.project_name,
-                "Contacts": self.contacts_str,
-                "Tasks": self.task
-                }
-        with open(self.exp_path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames)
+            "Sample_Name": sample_name,
+            "Project": self.project_name,
+            "Contacts": self.contacts_str,
+            "Tasks": self.task
+            }
+        with open(self.exp_path, "w", newline="") as f_out:
+            writer = csv.DictWriter(f_out, fieldnames)
             writer.writeheader()
             for sample_name in self.sample_names:
                 writer.writerow((exp_row(sample_name)))
 
-    def setUpProj(self):
+    def set_up_proj(self):
+        """Set up ProjectData object to be tested."""
         # Pull out the project we want (to support possibility of additional
         # projects under this run+alignment)
-        projs = ProjectData.from_alignment(self.alignment,
-                self.path_exp,
-                self.path_status,
-                self.path_proc,
-                self.path_pack,
-                self.uploader,
-                self.mailer)
+        projs = ProjectData.from_alignment(
+            self.alignment,
+            self.path_exp,
+            self.path_status,
+            self.path_proc,
+            self.path_pack,
+            self.uploader,
+            self.mailer)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
 
-    def fake_fastq_entry(self, seq, qual):
+    def fake_fastq(self, seq_pair, readlen=100):
+        """Helper to create a fake FASTQ file pair for one sample."""
+        fastq_paths = self.alignment.sample_paths_for_num(1)
+        for proj in fastq_paths:
+            proj.chmod(0o644)
+        adp = illumina.util.ADAPTERS["Nextera"]
+        fills = ("G", "A")
+        for path, seq, adpt, fill in zip(fastq_paths, seq_pair, adp, fills):
+            read = (seq + adpt).ljust(readlen, fill)
+            read = read[0:min(readlen, len(read))]
+            qual = ("@" * len(seq)) + ("!" * (len(read)-len(seq)))
+            with gzip.open(path, "wt") as f_gz:
+                f_gz.write(self._fake_fastq_entry(read, qual))
+
+    @staticmethod
+    def _fake_fastq_entry(seq, qual):
         # TODO can I just md5(seq)? check back on this.
         name = hashlib.md5(seq.encode("utf-8")).hexdigest()
         txt = "@%s\n%s\n+\n%s\n" % (name, seq, qual)
-        return(txt)
-
-    def fake_fastq(self, seq_pair, readlen=100):
-        fastq_paths = self.alignment.sample_paths_for_num(1)
-        [p.chmod(0o644) for p in fastq_paths]
-        adp = illumina.util.ADAPTERS["Nextera"]
-        fills = ("G", "A")
-        for path, seq, a, fill in zip(fastq_paths, seq_pair, adp, fills):
-            read = (seq + a).ljust(readlen, fill)
-            read = read[0:min(readlen, len(read))]
-            qual = ("@" * len(seq)) + ("!" * (len(read)-len(seq)))
-            with gzip.open(path, "wt") as gz:
-                gz.write(self.fake_fastq_entry(read, qual))
+        return txt
 
     def expected_paths(self, suffix=".trimmed.fastq", r1only=False):
+        """Helper to predict the expected FASTQ file paths."""
         paths = []
         for sample in self.sample_names:
             i = self.alignment.sample_names.index(sample)
-            p = self.alignment.sample_files_for_num(i+1) # (1-indexed)
+            fps = self.alignment.sample_files_for_num(i+1) # (1-indexed)
             if r1only:
-                paths.append(re.sub("_R1_", "_R_", p[0]))
+                paths.append(re.sub("_R1_", "_R_", fps[0]))
             else:
-                paths.extend(p)
+                paths.extend(fps)
         paths = [re.sub("\\.fastq\\.gz$", suffix, p) for p in paths]
         paths = sorted(paths)
-        return(paths)
+        return paths
 
     def check_log(self):
         """Does the log file exist?
@@ -307,8 +327,8 @@ class TestProjectDataOneTask(TestBase):
 
         This will also check for the YAML metadata file in the expected hidden
         location."""
-        with zipfile.ZipFile(self.proj.path_pack, "r") as z:
-            info = z.infolist()
+        with zipfile.ZipFile(self.proj.path_pack, "r") as f_zip:
+            info = f_zip.infolist()
             # Check compression status.  It should actually be compressed, and
             # with the expected method.
             item = info[0]
@@ -316,24 +336,30 @@ class TestProjectDataOneTask(TestBase):
             self.assertEqual(item.compress_type, zipfile.ZIP_DEFLATED)
             # Check that the expected files are all present in the zipfile.
             files = [i.filename for i in info]
-            for f in files_exp:
-                p = Path(self.proj.work_dir) / self.run.run_id / f
-                with self.subTest(p=p):
-                    self.assertIn(str(p), files)
+            for fp_exp in files_exp:
+                path = Path(self.proj.work_dir) / self.runobj.run_id / fp_exp
+                with self.subTest(path=path):
+                    self.assertIn(str(path), files)
 
     def test_attrs(self):
-        s = self.path_status / self.run.run_id / "0"
+        """Test various ProjectData properties."""
+        path_stat = self.path_status / self.runobj.run_id / "0"
         self.assertEqual(self.proj.name, self.project_name)
         self.assertEqual(self.proj.alignment, self.alignment)
-        self.assertEqual(self.proj.path, s / (self.project_name + ".yml"))
+        self.assertEqual(
+            self.proj.path,
+            path_stat / (self.project_name + ".yml"))
 
     def test_work_dir(self):
+        """Test the work_dir property string."""
         self.assertEqual(self.proj.work_dir, self.work_dir_exp)
 
     def test_readonly(self):
+        """Test the readonly property."""
         self.assertFalse(self.proj.readonly)
 
     def test_status(self):
+        """Test the status property."""
         # Here, we started from scratch.
         self.assertEqual(self.proj.status, "none")
         # Is the setter protecting against invalid values?
@@ -341,35 +367,40 @@ class TestProjectDataOneTask(TestBase):
             self.proj.status = "invalid status"
         # is the setter magically keeping the data on disk up to date?
         self.proj.status = "processing"
-        with open(self.proj.path) as f:
+        with open(self.proj.path) as f_in:
             with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",category=DeprecationWarning)
-                data = yaml.safe_load(f)
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                data = yaml.safe_load(f_in)
             self.assertEqual(data["status"], "processing")
 
     def test_experiment_info(self):
+        """Test the experiment_info dict property."""
         if hasattr(self, "tasks_listed"):
+            # pylint: disable=no-member
             tasks = self.tasks_listed
         else:
             tasks = [self.task]
         exp_info = {
-                "name": self.exp_name,
-                "sample_names": self.sample_names,
-                "tasks": tasks,
-                "contacts": self.contacts,
-                "path": self.exp_path
-                }
+            "name": self.exp_name,
+            "sample_names": self.sample_names,
+            "tasks": tasks,
+            "contacts": self.contacts,
+            "path": self.exp_path
+            }
         self.assertEqual(self.proj.experiment_info, exp_info)
 
     # Test task properties, at start
 
     def test_tasks_pending(self):
+        """Test the tasks_pending list property."""
         self.assertEqual(self.proj.tasks_pending, self.tasks_run)
 
     def test_tasks_completed(self):
+        """Test the tasks_completed list property."""
         self.assertEqual(self.proj.tasks_completed, [])
 
     def test_task_current(self):
+        """Test the task_current property."""
         self.assertEqual(self.proj.task_current, "")
 
     # After processing, we should see the change in each task property.
@@ -422,13 +453,13 @@ class TestProjectDataCopy(TestProjectDataOneTask):
         # The top-level work directory should contain the run directory and the
         # default Metadata directory.
         dirpath = self.proj.path_proc
-        dir_exp = sorted(["Metadata", "logs", self.run.run_id])
-        dir_obs = sorted([x.name for x in (dirpath.glob("*"))])
+        dir_exp = sorted(["Metadata", "logs", self.runobj.run_id])
+        dir_obs = sorted([x.name for x in dirpath.glob("*")])
         self.assertEqual(dir_obs, dir_exp)
         # The files in the top-level of the run directory should match, too.
         files_in = lambda d, s: [x.name for x in d.glob(s) if x.is_file()]
-        files_exp = sorted(files_in(self.run.path, "*"))
-        files_obs = sorted(files_in(dirpath / self.run.run_id, "*"))
+        files_exp = sorted(files_in(self.runobj.path, "*"))
+        files_obs = sorted(files_in(dirpath / self.runobj.run_id, "*"))
         self.assertEqual(files_obs, files_exp)
         self.check_zipfile(files_exp)
 
@@ -465,10 +496,10 @@ class TestProjectDataTrim(TestProjectDataOneTask):
         self.assertEqual(files_all, fastq_exp)
         # Did the specific read pair we created get trimmed as expected?
         pat = str(dirpath / "1086S1-01_S1_L001_R%d_001.trimmed.fastq")
-        fps = [pat % d for d in (1,2)]
-        for fp, seq_exp in zip(fps, seq_pair):
-            with open(fp, "r") as f:
-                seq_obs = f.readlines()[1].strip()
+        fps = [pat % d for d in (1, 2)]
+        for fp_in, seq_exp in zip(fps, seq_pair):
+            with open(fp_in, "r") as f_in:
+                seq_obs = f_in.readlines()[1].strip()
                 self.assertEqual(seq_obs, seq_exp)
 
 
@@ -511,10 +542,10 @@ class TestProjectDataMerge(TestProjectDataOneTask):
         # (This isn't super thorough since in this case it's just the same as
         # concatenating the two files.  Maybe add more to prove they're
         # interleaved.)
-        fp = str(dirpath / "1086S1-01_S1_L001_R_001.merged.fastq")
-        with open(fp, "r") as f:
-            data = f.readlines()
-            seq_obs = [data[i].strip() for i in [1,5]]
+        fp_in = str(dirpath / "1086S1-01_S1_L001_R_001.merged.fastq")
+        with open(fp_in, "r") as f_in:
+            data = f_in.readlines()
+            seq_obs = [data[i].strip() for i in [1, 5]]
             self.assertEqual(seq_obs, seq_pair)
 
 
@@ -524,7 +555,6 @@ class TestProjectDataMergeSingleEnded(TestProjectDataMerge):
 
     What *should* happen here?  (What does the original trim script do?)
     """
-    pass
 
 
 class TestProjectDataSpades(TestProjectDataOneTask):
@@ -602,12 +632,13 @@ class TestProjectDataManual(TestProjectDataOneTask):
         super().setUp()
 
     def finish_manual(self):
+        """Helper for manual processing test in test_process."""
         (self.proj.path_proc / "Manual").mkdir()
 
     def test_process(self):
         # It should finish as long as it finds the Manual directory
-        t = threading.Timer(1, self.finish_manual)
-        t.start()
+        timer = threading.Timer(1, self.finish_manual)
+        timer.start()
         super().test_process()
 
 
@@ -623,29 +654,31 @@ class TestProjectDataGeneious(TestProjectDataOneTask):
         self.tasks_run = ["trim", "merge", "spades", "assemble", "geneious"] + DEFAULT_TASKS
         super().setUpVars()
 
-    def setUpProj(self):
-        self.tasks_config  = {
+    def set_up_proj(self):
+        self.tasks_config = {
             "implicit_tasks_path": "RunDiagnostics/ImplicitTasks"
             }
-        projs = ProjectData.from_alignment(self.alignment,
+        projs = ProjectData.from_alignment(
+            self.alignment,
             self.path_exp,
             self.path_status,
             self.path_proc,
             self.path_pack,
             self.uploader,
             self.mailer,
-            conf = self.tasks_config)
+            conf=self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
 
     def finish_manual(self):
+        """Helper for manual processing test in test_process."""
         (self.proj.path_proc / "Geneious").mkdir()
 
     def test_process(self):
         # It should finish as long as it finds the Geneious directory
-        t = threading.Timer(1, self.finish_manual)
-        t.start()
+        timer = threading.Timer(1, self.finish_manual)
+        timer.start()
         super().test_process()
         # Despite the config, these directories should now be at the top level.
         self.assertTrue((self.proj.path_proc / "PairedReads").exists())
@@ -673,14 +706,14 @@ class TestProjectDataMetadata(TestProjectDataOneTask):
         # YAML for this project
         path_root = Path(self.proj.path_proc) / "Metadata"
         paths = {
-                "sample_sheet": path_root / "SampleSheetUsed.csv",
-                "metadata":     path_root / "metadata.csv",
-                "yaml":         path_root / self.proj.path.name
-                }
+            "sample_sheet": path_root / "SampleSheetUsed.csv",
+            "metadata":     path_root / "metadata.csv",
+            "yaml":         path_root / self.proj.path.name
+            }
         path_md5s = {
-                "sample_sheet": "1fbbfa008ef3038560e9904f3d8579a2",
-                "metadata":     "5ef2284fced0e08105c0670518ae2eae"
-                }
+            "sample_sheet": "1fbbfa008ef3038560e9904f3d8579a2",
+            "metadata":     "5ef2284fced0e08105c0670518ae2eae"
+            }
         # First off, they should all be there.
         for path in paths.values():
             self.assertTrue(path.exists())
@@ -689,24 +722,24 @@ class TestProjectDataMetadata(TestProjectDataOneTask):
         for key, md5_exp in path_md5s.items():
             with self.subTest(md_file=key):
                 path = paths[key]
-                with open(path, 'rb') as f:
-                    contents = f.read().decode("ASCII")
+                with open(path, 'rb') as f_in:
+                    contents = f_in.read().decode("ASCII")
                 md5_obs = md5(contents)
                 self.assertEqual(md5_obs, md5_exp)
 
     def write_test_experiment(self):
         # We need a more nuanced experiment metadata spreadsheet here to test
         # that only this project's rows are copied.
-        fieldnames = ["Sample_Name","Project","Contacts","Tasks"]
+        fieldnames = ["Sample_Name", "Project", "Contacts", "Tasks"]
         exp_row = lambda sample_name, pname: {
-                "Sample_Name": sample_name,
-                "Project": pname,
-                "Contacts": self.contacts_str,
-                "Tasks": self.task
-                }
+            "Sample_Name": sample_name,
+            "Project": pname,
+            "Contacts": self.contacts_str,
+            "Tasks": self.task
+            }
         sample_names_extra = ["1086S1_05", "1086S2_01", "1086S2_02", "1086S2_03"]
-        with open(self.exp_path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames)
+        with open(self.exp_path, "w", newline="") as f_out:
+            writer = csv.DictWriter(f_out, fieldnames)
             writer.writeheader()
             for sample_name in self.sample_names:
                 writer.writerow((exp_row(sample_name, self.project_name)))
@@ -776,16 +809,16 @@ class TestProjectDataEmail(TestProjectDataOneTask):
         # bit bulky.
         email_obs = self.mails
         self.assertEqual(len(email_obs), 1)
-        m = email_obs[0]
+        msg = email_obs[0]
         keys_exp = ["msg_body", "msg_html", "subject", "to_addrs"]
-        self.assertEqual(sorted(m.keys()), keys_exp)
+        self.assertEqual(sorted(msg.keys()), keys_exp)
         subject_exp = "Illumina Run Processing Complete for %s" % \
             self.proj.work_dir
         to_addrs_exp = self.to_addrs_exp
-        self.assertEqual(md5(m["msg_body"]), self.msg_body)
-        self.assertEqual(md5(m["msg_html"]), self.msg_html)
-        self.assertEqual(m["subject"], subject_exp)
-        self.assertEqual(m["to_addrs"], to_addrs_exp)
+        self.assertEqual(md5(msg["msg_body"]), self.msg_body)
+        self.assertEqual(md5(msg["msg_html"]), self.msg_html)
+        self.assertEqual(msg["subject"], subject_exp)
+        self.assertEqual(msg["to_addrs"], to_addrs_exp)
 
 
 class TestProjectDataEmailOneName(TestProjectDataEmail):
@@ -880,12 +913,13 @@ class TestProjectDataFilesExist(TestProjectDataOneTask):
 
     def setUp(self):
         # Here we'll get a warning from within __init__ about the unexpected
-        # subdirectory (see setUpPreProject below).  We'll check other
+        # subdirectory (see set_up_pre_project below).  We'll check other
         # attributes in the tests.
-        with self.assertLogs(level = logging.WARNING):
+        with self.assertLogs(level=logging.WARNING):
             super().setUp()
 
-    def setUpPreProject(self):
+    def set_up_pre_project(self):
+        """Hook to be run before initializing the ProjectData object itself."""
         # Put something inside the processing directory that will trip up
         # ProjectData initialization.
         (self.path_proc / self.work_dir_exp / "subdir").mkdir(parents=True)
@@ -919,20 +953,21 @@ class TestProjectDataMissingSamples(TestProjectDataOneTask):
         super().setUpVars()
         # Include an extra sample in the experiment metadata spreadsheet that
         # won't be in the run data.
-        self.sample_names = ["1086S1_01", "1086S1_02", "1086S1_03", "1086S1_04",
-                "somethingelse"]
+        self.sample_names = [
+            "1086S1_01", "1086S1_02", "1086S1_03", "1086S1_04", "somethingelse"]
 
-    def setUpProj(self):
+    def set_up_proj(self):
         # The project should be initialized fine, but with a warning logged
         # about the sample name mismatch.
-        with self.assertLogs(level = logging.WARNING):
-            projs = ProjectData.from_alignment(self.alignment,
-                    self.path_exp,
-                    self.path_status,
-                    self.path_proc,
-                    self.path_pack,
-                    self.uploader,
-                    self.mailer)
+        with self.assertLogs(level=logging.WARNING):
+            projs = ProjectData.from_alignment(
+                self.alignment,
+                self.path_exp,
+                self.path_status,
+                self.path_proc,
+                self.path_pack,
+                self.uploader,
+                self.mailer)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
@@ -952,15 +987,16 @@ class TestProjectDataNoSamples(TestProjectDataOneTask):
         # won't be in the run data.
         self.sample_names = ["somethingelse1", "somethingelse2"]
 
-    def setUpProj(self):
-        with self.assertLogs(level = logging.ERROR):
-            projs = ProjectData.from_alignment(self.alignment,
-                    self.path_exp,
-                    self.path_status,
-                    self.path_proc,
-                    self.path_pack,
-                    self.uploader,
-                    self.mailer)
+    def set_up_proj(self):
+        with self.assertLogs(level=logging.ERROR):
+            projs = ProjectData.from_alignment(
+                self.alignment,
+                self.path_exp,
+                self.path_status,
+                self.path_proc,
+                self.path_pack,
+                self.uploader,
+                self.mailer)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
@@ -995,29 +1031,34 @@ class TestProjectDataPathConfig(TestProjectDataOneTask):
         self.tasks_run = ["trim", self.task] + DEFAULT_TASKS
         super().setUpVars()
 
-    def setUpProj(self):
-        self.tasks_config  = {
+    def set_up_proj(self):
+        self.tasks_config = {
             "log_path": "RunDiagnostics/logs",
             "implicit_tasks_path": "RunDiagnostics/ImplicitTasks"
             }
-        projs = ProjectData.from_alignment(self.alignment,
+        projs = ProjectData.from_alignment(
+            self.alignment,
             self.path_exp,
             self.path_status,
             self.path_proc,
             self.path_pack,
             self.uploader,
             self.mailer,
-            conf = self.tasks_config)
+            conf=self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
 
     def test_process(self):
         super().test_process()
-        metadata_path = self.proj.path_proc / self.tasks_config["implicit_tasks_path"] / "Metadata"
+        metadata_path = (
+            self.proj.path_proc /
+            self.tasks_config["implicit_tasks_path"] /
+            "Metadata")
         self.assertTrue(metadata_path.exists())
         trim_path_default = self.proj.path_proc / "trimmed"
-        trim_path = (self.proj.path_proc /
+        trim_path = (
+            self.proj.path_proc /
             self.tasks_config["implicit_tasks_path"] /
             "trimmed")
         merge_path = self.proj.path_proc / "PairedReads"
@@ -1029,7 +1070,10 @@ class TestProjectDataPathConfig(TestProjectDataOneTask):
 
     def check_log(self):
         """Override default log path when checking to match config."""
-        logpath = self.proj.path_proc / self.tasks_config["log_path"] / ("log_"+self.task+".txt")
+        logpath = (
+            self.proj.path_proc /
+            self.tasks_config["log_path"] /
+            ("log_"+self.task+".txt"))
         self.assertTrue(logpath.exists())
 
 
@@ -1044,25 +1088,29 @@ class TestProjectDataImplicitTasks(TestProjectDataOneTask):
         self.task = "trim"
         super().setUpVars()
 
-    def setUpProj(self):
-        self.tasks_config  = {
+    def set_up_proj(self):
+        self.tasks_config = {
             "implicit_tasks_path": "RunDiagnostics/ImplicitTasks"
             }
-        projs = ProjectData.from_alignment(self.alignment,
+        projs = ProjectData.from_alignment(
+            self.alignment,
             self.path_exp,
             self.path_status,
             self.path_proc,
             self.path_pack,
             self.uploader,
             self.mailer,
-            conf = self.tasks_config)
+            conf=self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
 
     def test_process(self):
         super().test_process()
-        metadata_path = self.proj.path_proc / self.tasks_config["implicit_tasks_path"] / "Metadata"
+        metadata_path = (
+            self.proj.path_proc /
+            self.tasks_config["implicit_tasks_path"] /
+            "Metadata")
         self.assertTrue(metadata_path.exists())
         # Trim path should not have changed.
         trim_path = self.proj.path_proc / "trimmed"
@@ -1080,19 +1128,20 @@ class TestProjectDataExplicitTasks(TestProjectDataOneTask):
         self.task = "trim"
         super().setUpVars()
 
-    def setUpProj(self):
+    def set_up_proj(self):
         self.tasks_config = {
             "implicit_tasks_path": "RunDiagnostics/ImplicitTasks",
             "always_explicit_tasks": ["metadata"]
             }
-        projs = ProjectData.from_alignment(self.alignment,
-                                           self.path_exp,
-                                           self.path_status,
-                                           self.path_proc,
-                                           self.path_pack,
-                                           self.uploader,
-                                           self.mailer,
-                                           conf=self.tasks_config)
+        projs = ProjectData.from_alignment(
+            self.alignment,
+            self.path_exp,
+            self.path_status,
+            self.path_proc,
+            self.path_pack,
+            self.uploader,
+            self.mailer,
+            conf=self.tasks_config)
         for proj in projs:
             if proj.name == self.project_name:
                 self.proj = proj
@@ -1109,17 +1158,20 @@ class TestProjectDataExplicitTasks(TestProjectDataOneTask):
 
 
 class TestProjectDataBlank(TestProjectDataOneTask):
-    # TODO test with no tasks at all
-    # this just needs to confim that the TASK_NULL code correctly inserts
-    # "copy" when nothing else is specified.  put it in self.tasks_run.
-    pass
+    """Test with no tasks at all.
+
+    This just needs to confim that the TASK_NULL code correctly inserts "copy"
+    when nothing else is specified.  put it in self.tasks_run.
+    """
+    # TODO
 
 
 class TestProjectDataAlreadyProcessing(TestBase):
+    """Test project whose existing metadata points to an existant process.
 
-    # TODO test the case of having a project whose existing metadata points to
-    # an already-running process.  We should abort in that case.
-    pass
+    We should abort in that case.
+    """
+    # TODO
 
 
 if __name__ == '__main__':

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -13,7 +13,6 @@ that.
 import unittest
 import re
 import csv
-import hashlib
 import gzip
 import zipfile
 import warnings
@@ -295,8 +294,7 @@ class TestProjectDataOneTask(TestBase):
 
     @staticmethod
     def _fake_fastq_entry(seq, qual):
-        # TODO can I just md5(seq)? check back on this.
-        name = hashlib.md5(seq.encode("utf-8")).hexdigest()
+        name = md5(seq)
         txt = "@%s\n%s\n+\n%s\n" % (name, seq, qual)
         return txt
 
@@ -1157,21 +1155,21 @@ class TestProjectDataExplicitTasks(TestProjectDataOneTask):
         self.assertTrue(trim_path.exists())
 
 
+@unittest.skip("not yet implemented")
 class TestProjectDataBlank(TestProjectDataOneTask):
     """Test with no tasks at all.
 
     This just needs to confim that the TASK_NULL code correctly inserts "copy"
     when nothing else is specified.  put it in self.tasks_run.
     """
-    # TODO
 
 
+@unittest.skip("not yet implemented")
 class TestProjectDataAlreadyProcessing(TestBase):
     """Test project whose existing metadata points to an existant process.
 
     We should abort in that case.
     """
-    # TODO
 
 
 if __name__ == '__main__':

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -10,13 +10,21 @@ multiple simultaneous projects, either; see test_umbra.py for
 that.
 """
 
-from .test_common import *
+import unittest
+import re
+import csv
+import hashlib
 import gzip
 import zipfile
 import warnings
-import yaml
 import threading
-import time
+import logging
+from pathlib import Path
+import yaml
+from umbra import (illumina,  util)
+from umbra.illumina.run import Run
+from umbra.project import (ProjectData, ProjectError)
+from .test_common import TestBase, md5
 
 DEFAULT_TASKS = ["metadata", "package", "upload", "email"]
 

--- a/test_umbra/test_task.py
+++ b/test_umbra/test_task.py
@@ -46,10 +46,12 @@ class TestTaskClass(unittest.TestCase):
 
     def test_name(self):
         """Test that the name property is defined."""
+        # pylint: disable=no-member
         self.assertEqual(self.thing.name, "task")
 
     def test_source_path(self):
         """Test that source_path is a Path pointing to the source code."""
+        # pylint: disable=no-member
         self.assertEqual(self.thing.source_path, Path("__init__.py"))
 
     def test_order(self):

--- a/umbra/box_uploader.py
+++ b/umbra/box_uploader.py
@@ -122,7 +122,7 @@ class BoxUploader:
         self.logger.info("File uploaded: %s", str(path))
         return url
 
-    def _list(self, chunk=100):
+    def list(self, chunk=100):
         """List of file and folder objects in the uploader folder."""
         offset = 0
         items = self.folder.get_items(chunk)

--- a/umbra/illumina/alignment.py
+++ b/umbra/illumina/alignment.py
@@ -89,7 +89,10 @@ class Alignment:
     def experiment(self):
         """Experiment name given in sample sheet."""
         hdr = self.sample_sheet["Header"]
-        # MiSeq vs MiniSeq
+        # I've seen both versions across multiple MiSeqs, but just the space
+        # one for MiniSeq, where the machine creates its own sample sheet from
+        # a separate input spreadsheet.  Maybe Illumina's parsing is flexible
+        # but officially it prefers the space?
         exp = hdr.get("Experiment_Name") or hdr.get("Experiment Name")
         return exp
 

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -37,11 +37,11 @@ class ProjectData:
     """
 
     # ProjectData processing status enumerated type.
-    NONE          = "none"
-    PROCESSING    = "processing"
+    NONE = "none"
+    PROCESSING = "processing"
     PACKAGE_READY = "package-ready"
-    COMPLETE      = "complete"
-    FAILED        = "failed"
+    COMPLETE = "complete"
+    FAILED = "failed"
     STATUS = [NONE, PROCESSING, PACKAGE_READY, COMPLETE, FAILED]
 
     @staticmethod

--- a/umbra/task/__init__.py
+++ b/umbra/task/__init__.py
@@ -141,6 +141,14 @@ class Task(metaclass=__TaskParent):
     information.
     """
 
+    # The inheritance and introspection going on here is pretty weird and it
+    # confuses pylint (it'll complain about missing members when they really
+    # are there if you check them on live objects).  Maybe there are clever
+    # ways to fix this but I'm just turning off the no-member check in each
+    # task class where it comes up, like so:
+    # pylint: disable=no-member
+    # maybe relevant? https://stackoverflow.com/q/38087760
+
     # Task execution order.
     # A higher number means run later than tasks with lower numbers.  This
     # default setting will run after the core processing tasks but before the

--- a/umbra/task/task_assemble.py
+++ b/umbra/task/task_assemble.py
@@ -4,11 +4,14 @@ import re
 from Bio import SeqIO
 from umbra import task
 
+
 class TaskAssemble(task.Task):
     """Assemble contigs from all samples.
 
     This handles de-novo assembly with Spades and some of our own
     post-processing."""
+
+    # pylint: disable=no-member
 
     order = 13
     dependencies = ["spades", "merge"]

--- a/umbra/task/task_copy.py
+++ b/umbra/task/task_copy.py
@@ -6,6 +6,7 @@ from umbra import task
 class TaskCopy(task.Task):
     """Copy the run directory into the processing directory."""
 
+    # pylint: disable=no-member
     order = 2
 
     def run(self):

--- a/umbra/task/task_copy.py
+++ b/umbra/task/task_copy.py
@@ -11,6 +11,6 @@ class TaskCopy(task.Task):
 
     def run(self):
         src = str(self.proj.alignment.run.path)
-        dest = str(self._task_dir_parent(self.name) /
+        dest = str(self.task_dir_parent(self.name) /
                    self.proj.alignment.run.run_id)
         copy_tree(src, dest)

--- a/umbra/task/task_geneious.py
+++ b/umbra/task/task_geneious.py
@@ -17,9 +17,9 @@ class TaskGeneious(task.Task):
         # Override the implicit task hiding for this specific case.  This
         # is brittle but should work for the time being.
         paths_move = [
-            self._task_dir_parent("merge")/"PairedReads",
-            self._task_dir_parent("assemble")/"ContigsGeneious",
-            self._task_dir_parent("assemble")/"CombinedGeneious"
+            self.task_dir_parent("merge")/"PairedReads",
+            self.task_dir_parent("assemble")/"ContigsGeneious",
+            self.task_dir_parent("assemble")/"CombinedGeneious"
             ]
         for path in paths_move:
             if path.parent != self.proj.path_proc:

--- a/umbra/task/task_merge.py
+++ b/umbra/task/task_merge.py
@@ -13,15 +13,15 @@ class TaskMerge(task.Task):
     dependencies = ["trim"]
 
     def run(self):
-        for samp in self.sample_paths.keys():
+        for samp in self.sample_paths:
             paths = self.sample_paths[samp]
             if len(paths) != 2:
                 raise ProjectError("merging needs 2 files per sample")
             fqs_in = [self._get_tp(p) for p in paths]
-            fq_out = self.task_path(paths[0],
-                                    "merge",
-                                    "PairedReads",
-                                    ".merged.fastq")
+            fq_out = (
+                self.task_dir_parent(self.name) /
+                "PairedReads" /
+                self.read_file_product(paths[0], ".merged.fastq"))
             merge_pair(fq_out, fqs_in)
             # Merge each file pair. If the expected output file is missing,
             # raise an exception.
@@ -30,11 +30,14 @@ class TaskMerge(task.Task):
                 raise ProjectError(msg)
 
     def _get_tp(self, path):
-        return self.task_path(path, "trim", "trimmed", ".trimmed.fastq",
-                              r1only=False)
+        return (
+            self.task_dir_parent("trim") /
+            "trimmed" /
+            self.read_file_product(path, ".trimmed.fastq", merged=False))
 
 def merge_pair(fq_out, fqs_in):
     """Merge reads from the pair of input FASTQs to a single output FASTQ."""
+    task.mkparent(fq_out)
     with open(fq_out, "w") as f_out, \
             open(fqs_in[0], "r") as f_r1, \
             open(fqs_in[1], "r") as f_r2:

--- a/umbra/task/task_merge.py
+++ b/umbra/task/task_merge.py
@@ -8,6 +8,7 @@ from umbra.util import ProjectError
 class TaskMerge(task.Task):
     """Interleave forward and reverse reads for each sample."""
 
+    # pylint: disable=no-member
     order = 11
     dependencies = ["trim"]
 

--- a/umbra/task/task_metadata.py
+++ b/umbra/task/task_metadata.py
@@ -11,7 +11,7 @@ class TaskMetadata(task.Task):
     order = 1000
 
     def run(self):
-        dest = self._task_dir_parent(self.name) / "Metadata"
+        dest = self.task_dir_parent(self.name) / "Metadata"
         dest.mkdir(parents=True, exist_ok=True)
         paths = []
         paths.append(self.proj.alignment.path_sample_sheet) # Sample Sheet

--- a/umbra/task/task_metadata.py
+++ b/umbra/task/task_metadata.py
@@ -14,7 +14,7 @@ class TaskMetadata(task.Task):
         dest = self.task_dir_parent(self.name) / "Metadata"
         dest.mkdir(parents=True, exist_ok=True)
         paths = []
-        paths.append(self.proj.alignment.path_sample_sheet) # Sample Sheet
+        paths.append(self.proj.alignment.paths["sample_sheet"]) # Sample Sheet
         paths.append(self.proj.path) #  Project metadata YAML file (as it currently stands)
         for path in paths:
             shutil.copy(path, dest)

--- a/umbra/task/task_metadata.py
+++ b/umbra/task/task_metadata.py
@@ -7,6 +7,7 @@ from umbra import task
 class TaskMetadata(task.Task):
     """Copy metadata spreadsheets and YAML into working directory."""
 
+    # pylint: disable=no-member
     order = 1000
 
     def run(self):

--- a/umbra/task/task_spades.py
+++ b/umbra/task/task_spades.py
@@ -18,14 +18,17 @@ class TaskSpades(task.Task):
     def run(self):
         for samp in self.sample_paths.keys():
             paths = self.sample_paths[samp]
-            fq_merged = self.task_path(paths[0],
-                                       "merge",
-                                       "PairedReads",
-                                       ".merged.fastq")
-            spades_dir = self.task_path(paths[0], self.name, "assembled")
-            self._assemble_reads(fq_merged, spades_dir)
+            fq_merged = (
+                self.task_dir_parent("merge") /
+                "PairedReads" /
+                self.read_file_product(paths[0], ".merged.fastq"))
+            spades_dir = (
+                self.task_dir_parent(self.name) /
+                "assembled" /
+                self.read_file_product(paths[0]))
+            self.assemble_reads(fq_merged, spades_dir)
 
-    def _assemble_reads(self, fq_in, dir_out):
+    def assemble_reads(self, fq_in, dir_out):
         """Assemble a pair of read files with SPAdes.
 
         This runs spades.py on a single sample, saving the output to a given

--- a/umbra/task/task_spades.py
+++ b/umbra/task/task_spades.py
@@ -11,6 +11,7 @@ class TaskSpades(task.Task):
     This handles de-novo assembly with Spades and some of our own
     post-processing."""
 
+    # pylint: disable=no-member
     order = 12
     dependencies = ["merge"]
 
@@ -22,7 +23,7 @@ class TaskSpades(task.Task):
                                        "PairedReads",
                                        ".merged.fastq")
             spades_dir = self.task_path(paths[0], self.name, "assembled")
-            fa_contigs = self._assemble_reads(fq_merged, spades_dir)
+            self._assemble_reads(fq_merged, spades_dir)
 
     def _assemble_reads(self, fq_in, dir_out):
         """Assemble a pair of read files with SPAdes.
@@ -54,4 +55,3 @@ class TaskSpades(task.Task):
             self.logf.write("creating placeholder contig file.\n")
             touch(fp_out)
         return fp_out
-

--- a/umbra/task/task_trim.py
+++ b/umbra/task/task_trim.py
@@ -8,6 +8,7 @@ from umbra import task
 class TaskTrim(task.Task):
     """Trim adapters from raw fastq.gz files."""
 
+    # pylint: disable=no-member
     order = 10
 
     def run(self):

--- a/umbra/task/task_trim.py
+++ b/umbra/task/task_trim.py
@@ -20,12 +20,14 @@ class TaskTrim(task.Task):
             for i, path in enumerate(paths):
                 adapter = ADAPTERS["Nextera"][i]
                 fastq_in = str(path)
-                fastq_out = self.task_path(
-                    readfile=path,
-                    taskname=self.name,
-                    subdir="trimmed",
-                    suffix=".trimmed.fastq",
-                    r1only=False)
+                fastq_out = (
+                    self.task_dir_parent(self.name) /
+                    "trimmed" /
+                    self.read_file_product(
+                        path,
+                        ".trimmed.fastq",
+                        merged=False))
+                task.mkparent(fastq_out)
                 args = ["cutadapt", "-a", adapter, "-o", fastq_out, fastq_in]
                 # Call cutadapt with each file.  If the exit status is
                 # nonzero or if the expected output file is missing, this will


### PR DESCRIPTION
Various organization improvements:

 * syntax fixes
 * remove "*" imports
 * add docstrings throughout
 * group related class members together as lists/dictionaries

Also reorganizes path handling in tasks (read_file_product and and task_dir_parent)