### PR TITLE
Email task reorganization

### DIFF
--- a/test_umbra/test_task.py
+++ b/test_umbra/test_task.py
@@ -115,6 +115,7 @@ class TestTask(TestTaskClass):
             nthreads=1,
             config={},
             sample_paths={"sample_name": ["R1.fastq.gz", "R2.fastq.gz"]},
+            work_dir="work_dir_name",
             experiment_info={"tasks": []}
             )
         # Expected values during tests
@@ -122,12 +123,19 @@ class TestTask(TestTaskClass):
             "nthreads": 1,
             "log_path": self.proj.path_proc / "logs/log_task.txt",
             "sample_paths": copy.deepcopy(self.proj.sample_paths),
+            "work_dir_name": "work_dir_name",
             "task_dir_parent": self.proj.path_proc
             }
         self.thing = task.Task({}, self.proj)
 
     def tearDown(self):
         self.tmpdir.cleanup()
+
+    def test_work_dir_name(self):
+        """Test work_dir_name attribute that should come from the project."""
+        self.assertEqual(
+            self.thing.work_dir_name,
+            self.expected["work_dir_name"])
 
     def test_log_path(self):
         """Test log path attribute."""
@@ -280,6 +288,7 @@ class TestTaskImplicit(TestTask):
             config={
                 "implicit_tasks_path": Path(self.tmpdir.name)/"proc/implicit"},
             sample_paths={"sample_name": ["R1.fastq.gz", "R2.fastq.gz"]},
+            work_dir="work_dir_name",
             # Note, no tasks are requested but we're using one named "task"
             # in the tests here, so it should be considered implicit.
             experiment_info={"tasks": []}
@@ -289,6 +298,7 @@ class TestTaskImplicit(TestTask):
             "nthreads": 1,
             "log_path": self.proj.path_proc / "logs/log_task.txt",
             "sample_paths": copy.deepcopy(self.proj.sample_paths),
+            "work_dir_name": "work_dir_name",
             "task_dir_parent": self.proj.path_proc / "implicit"
             }
         self.thing = task.Task({}, self.proj)

--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -67,6 +67,30 @@ task_options:
     assemble:
       # Min length of contigs to keep in filtered Geneious-ready form
       contig_length_min: 255
+    email:
+      # These are the plaintext and HTML templates for outgoing notification
+      # emails when processing is complete.  Most people will probably see the
+      # HTML one though we provide plaintext just in case.  Available template
+      # variables are:
+      #  * work_dir: "short name" of this dataset, like "2019-04-26-project-person"
+      #  * url: file download URL as provided by the upload task.
+      template_text: |
+        Hello,
+
+        Illumina run processing is complete for {work_dir}
+        and a zip file with results can be downloaded from this url:
+
+        {url}
+      template_html: |
+        Hello,
+        <br><br>
+
+        Illumina run processing is complete for {work_dir}
+        and a zip file with results can be downloaded from this url:
+        <br><br>
+
+        <a href='{url}'>{url}</a>
+
 
 ##############################################################################
 # Options for the report displayed during the "report" action.

--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -68,28 +68,47 @@ task_options:
       # Min length of contigs to keep in filtered Geneious-ready form
       contig_length_min: 255
     email:
-      # These are the plaintext and HTML templates for outgoing notification
-      # emails when processing is complete.  Most people will probably see the
-      # HTML one though we provide plaintext just in case.  Available template
-      # variables are:
-      #  * work_dir: "short name" of this dataset, like "2019-04-26-project-person"
-      #  * url: file download URL as provided by the upload task.
+      # (This is for the email task specifically. For general email-sending
+      # configuration see the "mailer" header below.)
+      # These are the subject, plaintext body, and HTML body templates for
+      # outgoing notification emails when processing is complete.  (Most people
+      # will probably see the HTML one though we provide plaintext just in
+      # case).  Use curly braces around templated variables.  The task object
+      # is "self" when the template is filled in, so you can use references
+      # like:
+      #  * self.work_dir_name: "short name" of this dataset, like
+      #    "2019-04-26-project-person"
+      #  * self.url: file download URL as provided by the upload task.
+      template_subject: Illumina Run Processing Complete for {self.work_dir_name}
       template_text: |
         Hello,
 
-        Illumina run processing is complete for {work_dir}
+        Illumina run processing is complete for {self.work_dir_name}
         and a zip file with results can be downloaded from this url:
 
-        {url}
+        {self.url}
+
+        ========================================
+
+          Run: {self.proj.alignment.run.run_id}
+          Experiment: {self.proj.alignment.experiment}
+          Processing Status: {self.proj.path}
       template_html: |
         Hello,
         <br><br>
 
-        Illumina run processing is complete for {work_dir}
+        Illumina run processing is complete for {self.work_dir_name}
         and a zip file with results can be downloaded from this url:
         <br><br>
 
-        <a href='{url}'>{url}</a>
+        <a href='{self.url}'>{self.url}</a>
+        <br><br>
+
+        <small style="font-family: monospace; white-space: pre; color: gray;">
+          Run: {self.proj.alignment.run.run_id}
+          Experiment: {self.proj.alignment.experiment}
+          Processing Status: {self.proj.path}
+        </small>
 
 
 ##############################################################################

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -202,6 +202,11 @@ class ProjectData:
         return self._metadata["work_dir"]
 
     @property
+    def contacts(self):
+        """Dictionary of user contact info from experiment metadata."""
+        return self._metadata["experiment_info"]["contacts"].copy()
+
+    @property
     def sample_paths(self):
         """Dict mapping sample names to filesystem paths."""
         paths = self._metadata["sample_paths"]

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -192,6 +192,11 @@ class ProjectData:
         return self._metadata["experiment_info"]
 
     @property
+    def task_output(self):
+        """Dict of task output data."""
+        return self._metadata["task_output"]
+
+    @property
     def work_dir(self):
         """Short name for working directory, without path."""
         return self._metadata["work_dir"]

--- a/umbra/task/__init__.py
+++ b/umbra/task/__init__.py
@@ -193,6 +193,11 @@ class Task(metaclass=__TaskParent):
             self.logf.close()
 
     @property
+    def work_dir_name(self):
+        """Project work_dir."""
+        return self.proj.work_dir
+
+    @property
     def log_path(self):
         """Path to log file for this task."""
         path = (self.proj.path_proc /

--- a/umbra/task/__init__.py
+++ b/umbra/task/__init__.py
@@ -15,7 +15,9 @@ import logging
 import inspect
 import subprocess
 import traceback
+import copy
 from pathlib import Path
+from .. import config, CONFIG
 from ..util import mkparent
 
 # requires on PATH:
@@ -170,15 +172,19 @@ class Task(metaclass=__TaskParent):
         info = fmt % (cls.name, cls.order, ", ".join(cls.dependencies), cls.source_path)
         return info
 
-    def __init__(self, config, proj):
+    def __init__(self, conf, proj):
         """Task object initlization.
 
         When a task is created it will be given a dictionary of configuration
         information and a project data object with a bundle of run information
         and metadata.  If you override __init__ be sure to
-        super().__init__(config, proj).
+        super().__init__(conf, proj).
         """
-        self.config = config
+        # Start off with any package-level defaults for this task
+        default_config = CONFIG["task_options"]["tasks"].get(self.name, {})
+        self.config = copy.deepcopy(default_config)
+        # Layer on the given config, if any.
+        config.update_tree(self.config, conf or {})
         self.proj = proj
         self.logf = None
 

--- a/umbra/task/task_email.py
+++ b/umbra/task/task_email.py
@@ -1,6 +1,7 @@
 """Send notfication email for a finished ProjectData."""
 
 from umbra import task
+
 class TaskEmail(task.Task):
     """Send notfication email for a finished ProjectData."""
 
@@ -17,16 +18,8 @@ class TaskEmail(task.Task):
         url = self.proj._metadata["task_output"].get("upload", {}).get("url", "")
         subject = "Illumina Run Processing Complete for %s" % self.proj.work_dir
         # Build message text and html
-        body = "Hello,\n\n"
-        body += "Illumina run processing is complete for %s\n" % self.proj.work_dir
-        body += "and a zip file with results can be downloaded from this url:\n"
-        body += "\n%s\n" % url
-        html = "Hello,\n"
-        html += "<br><br>\n\n"
-        html += "Illumina run processing is complete for %s\n" % self.proj.work_dir
-        html += "and a zip file with results can be downloaded from this url:\n"
-        html += "<br><br>\n"
-        html += "\n<a href='%s'>%s</a>\n" % (url, url)
+        body = self.config["template_text"].format(work_dir=self.proj.work_dir, url=url)
+        html = self.config["template_html"].format(work_dir=self.proj.work_dir, url=url)
         # Send
         kwargs = {
             "to_addrs": contacts,


### PR DESCRIPTION
This moves the email subject and contents used in the email task into the configuration, and reorganizes some task/project attributes for easier referencing in the templates.