### PR TITLE
Add retry feature for Box uploads

### DIFF
--- a/test_umbra/shims/mock_boxsdk.py
+++ b/test_umbra/shims/mock_boxsdk.py
@@ -7,6 +7,7 @@ Mock-up of the boxsdk package for testing.
 # https://medium.com/@yeraydiazdiaz/what-the-mock-cheatsheet-mocking-in-python-6a71db997832
 
 from unittest.mock import (Mock, create_autospec, DEFAULT)
+from requests.exceptions import ConnectionError as RequestsConnectionError
 import boxsdk
 import boxsdk.exception
 
@@ -34,7 +35,9 @@ def setup_network_blip(numfails=1):
             FOLDER.uploads = 0
         try:
             if FOLDER.uploads < numfails:
-                raise OSError(32)
+                # Use the exception seen from the requests package, just like
+                # boxsdk actually does
+                raise RequestsConnectionError()
         finally:
             FOLDER.uploads += 1
         return DEFAULT

--- a/test_umbra/shims/mock_boxsdk.py
+++ b/test_umbra/shims/mock_boxsdk.py
@@ -1,0 +1,49 @@
+"""
+Mock-up of the boxsdk package for testing.
+"""
+
+# Should consider cleaning this up as per here, especially the "Mocking
+# classes" section:
+# https://medium.com/@yeraydiazdiaz/what-the-mock-cheatsheet-mocking-in-python-6a71db997832
+
+from unittest.mock import (Mock, create_autospec, DEFAULT)
+import boxsdk
+import boxsdk.exception
+
+# Objects used from boxsdk
+# pylint: disable=invalid-name
+exception = boxsdk.exception
+OAuth2 = create_autospec(boxsdk.OAuth2)
+Client = create_autospec(boxsdk.Client)
+Client.return_value.user.return_value.get = Mock(
+    return_value={"max_upload_size": 1024, "login": "login"})
+
+def setup_folder_get_items(folder):
+    "Re-usable side effect setup for the folder mock."""
+    folder.get_items = Mock(side_effect=[[], [0], []])
+
+def setup_network_blip(numfails=1):
+    """Simulate network failure during Box folder upload.
+
+    Set the returned function from this as the side effect for folder.upload to
+    test intermittent network failure.
+    """
+
+    def blip(*_, **__):
+        if not "uploads" in dir(FOLDER):
+            FOLDER.uploads = 0
+        try:
+            if FOLDER.uploads < numfails:
+                raise OSError(32)
+        finally:
+            FOLDER.uploads += 1
+        return DEFAULT
+
+    return blip
+
+# The folder object mock-up, with a very brittle assumption that on the first
+# get_items call nothing has been uploaded, on the second one file has, and on
+# the third there's nothing in the folder (so no need to clean anything up).
+# This matches how the tests interact with BoxUploader.
+FOLDER = Client.return_value.folder.return_value
+setup_folder_get_items(FOLDER)

--- a/test_umbra/test_box_uploader.py
+++ b/test_umbra/test_box_uploader.py
@@ -2,29 +2,33 @@
 """
 Test umbra.box_uploader
 
-More specifically, tests for BoxUploader objects.  If a file with real Box API
-credentials are supplied via the configuration, a live test will be run, over
-the Box API.  Otherwise Box tests are skipped.
+The Box SDK module is replaced with a mock version and local tests are run.  If
+a file with real Box API credentials are supplied via the configuration, a live
+test will also be run, over the real Box API.
 """
 
 import urllib.request
 import unittest
+import copy
+import sys
 from tempfile import NamedTemporaryFile
+from pathlib import Path
 from umbra.box_uploader import BoxUploader
 from .test_common import CONFIG
+from .shims import mock_boxsdk
 
 
 class TestBoxUploader(unittest.TestCase):
     """Test the BoxUploader class that handles file uploads to box.com."""
 
     def setUp(self):
-        box_config = CONFIG.get("box", {})
         msg = "Box credentials not supplied."
+        self.box_config = CONFIG.get("box", {})
         try:
-            path = box_config.get("credentials_path")
+            path = self.box_config.get("credentials_path")
             if not path:
                 raise unittest.SkipTest(msg)
-            self.box = BoxUploader(path, box_config)
+            self.box = BoxUploader(path, self.box_config)
         except FileNotFoundError:
             raise unittest.SkipTest(msg)
 
@@ -45,6 +49,78 @@ class TestBoxUploader(unittest.TestCase):
         self.assertEqual(data_obs, data_exp)
         self.assertEqual(len(self.box.list()), 1)
 
+
+class TestBoxUploaderMock(TestBoxUploader):
+    """Test the BoxUploader class using a mock connection."""
+
+    def setUp(self):
+        self.box_config = copy.deepcopy(CONFIG.get("box", {}))
+        self.setup_box_shim()
+        self.box = BoxUploader(
+            self.box_config.get("credentials_path"),
+            self.box_config)
+
+    # Based on:
+    # https://stackoverflow.com/a/1950214/4499968
+    # But, see the patching mechanism in unittest.mock.  That may be the right
+    # way to go.
+    def setup_box_shim(self):
+        """Setup testing shim module for the Box SDK."""
+        mock_boxsdk.setup_folder_get_items(mock_boxsdk.FOLDER)
+        self.real_boxsdk = sys.modules["umbra"].box_uploader.boxsdk
+        sys.modules["umbra"].box_uploader.boxsdk = mock_boxsdk
+        box_path = self.box_config.get("credentials_path")
+        if not box_path or not Path(box_path).exists():
+            box_path = NamedTemporaryFile().name
+            self.box_config["credentials_path"] = box_path
+            fakecreds = {
+                "client_id": "A",
+                "client_secret": "B",
+                "redirect_uri": "https://example.com"}
+            fakecreds = ["%s: %s\n" % (k, fakecreds[k]) for k in fakecreds]
+            with open(box_path, "w") as f_out:
+                f_out.writelines(fakecreds)
+
+    def teardown_box_shim(self):
+        """Swap testing shim module for the real Box SDK."""
+        # Tests seem to run fine either way but I don't like the idea that it
+        # leaves the fake module masking the real one.
+        sys.modules["umbra"].box_uploader.boxsdk = self.real_boxsdk
+
+    def tearDown(self):
+        self.teardown_box_shim()
+
+    def test_upload(self):
+        """Test uploading a file to Box."""
+        self.assertEqual(len(self.box.list()), 0)
+        data_exp = b"test_upload\n"
+        with NamedTemporaryFile() as ftmp:
+            ftmp.write(data_exp)
+            ftmp.flush()
+            self.box.upload(ftmp.name, "test_upload.txt")
+        upload_mock = mock_boxsdk.FOLDER.upload
+        upload_mock.assert_called()
+        self.assertEqual(len(self.box.list()), 1)
+
+
+class TestBoxUploaderMockDisconnect(TestBoxUploaderMock):
+    """Test the case where an upload attempt is interrupted."""
+
+    def setUp(self):
+        mock_boxsdk.FOLDER.upload.side_effect = mock_boxsdk.setup_network_blip(1)
+        super().setUp()
+
+    def test_upload(self):
+        self.assertEqual(len(self.box.list()), 0)
+        data_exp = b"test_upload\n"
+        with NamedTemporaryFile() as ftmp:
+            ftmp.write(data_exp)
+            ftmp.flush()
+            with self.assertLogs(level="WARNING") as logging_context:
+                self.box.upload(ftmp.name, "test_upload.txt")
+                self.assertEqual(len(logging_context.output), 2)
+        mock_boxsdk.FOLDER.upload.assert_called()
+        self.assertEqual(len(self.box.list()), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a feature to BoxUploader.upload for fault-tolerant file uploads.  Any sort of IOError will be caught and logged for up to a certain number of tries before allowing the last exception to propagate.  This also updates the tests for BoxUploader to use a mock version of the boxsdk package (in order to trigger the exception during an attempted upload).  Fixes #51.