### PR TITLE
Remove quote characters when matching sample names to file names

### DIFF
--- a/umbra/illumina/alignment.py
+++ b/umbra/illumina/alignment.py
@@ -147,7 +147,7 @@ class Alignment:
         # SEE: 171026_M00281_0285_000000000-BGM65
         if not sname:
             sname = sample["Sample_ID"]
-        sname = re.sub(r"[/+#_ .\-]+", "-", sname)
+        sname = re.sub(r"[/+#_ .\-'\"]+", "-", sname)
         sname = re.sub("-+$", "", sname)
         sname = re.sub("^-+", "", sname)
         fields = {"sname": sname, "snum": sample_num, "lane": 1, "rp": 1}


### PR DESCRIPTION
Our list of special characters was missing single and double quotes, and from experience single quotes and presumably double quotes are included in the substitution for sample file names.  In the long run it would probably be safer to use a list of allowed instead of disallowed characters, and maybe safer yet to use sample numbers instead of names and match the suffix of the paths.  But this fixes #62 at least.