### PR TITLE
Timeout feature for manual and geneious tasks

### DIFF
--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -702,7 +702,7 @@ class TestProjectDataTimeout(TestProjectDataOneTask):
             self.proj.process()
         self.assertEqual(self.proj.status, self.expected["final_status"])
         self.assertEqual(self.proj.tasks_pending, DEFAULT_TASKS)
-        self.assertEqual(self.proj.tasks_completed, [])
+        self.assertEqual(self.proj.tasks_completed, self.expected["tasks_completed"])
         self.assertEqual(self.proj.task_current, self.task)
 
 
@@ -717,6 +717,7 @@ class TestProjectDataManualTimeout(TestProjectDataTimeout):
         self.task = "manual"
         super().set_up_vars()
         self.expected["final_status"] = "failed"
+        self.expected["tasks_completed"] = []
 
     def test_process(self):
         self.check_process()
@@ -768,11 +769,19 @@ class TestProjectDataGeneiousTimeout(TestProjectDataTimeout):
         self.task = "geneious"
         super().set_up_vars()
         self.expected["final_status"] = "failed"
-        self.expected["tasks"] = ["trim", "merge", "spades", "assemble",
-                                  "geneious"] + DEFAULT_TASKS
+        tasks = ["trim", "merge", "spades", "assemble"]
+        self.expected["tasks_completed"] = tasks
+        self.expected["tasks"] = tasks + ["geneious"] + DEFAULT_TASKS
+        self.expected["task_output"] = {t: {} for t in tasks}
 
     def test_process(self):
         self.check_process()
+
+    def test_task_output(self):
+        self.test_process()
+        self.assertEqual(
+            sorted(self.proj.task_output.keys()),
+            sorted(self.expected["task_output"].keys()))
 
 
 class TestProjectDataMetadata(TestProjectDataOneTask):

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -664,6 +664,64 @@ class TestProjectDataManual(TestProjectDataOneTask):
         super().test_process()
 
 
+class TestProjectDataTimeout(TestProjectDataOneTask):
+    """Abstract base for TestProjectDataManualTimeout and GeneiousTimeout below."""
+
+    def set_up_proj(self):
+        """Set up project with customized task options.
+
+        We need to override the timing settings to something short enough to
+        test here.
+        """
+        super().set_up_proj()
+        task = [task for task in self.proj.tasks if task.name == self.task][0]
+        task.config["timeout"] = 1
+        task.config["delta"] = 0.5
+
+    def finish_manual(self):
+        """Helper for manual processing test in test_process.
+
+        By the time this runs (if ever) processing should already have failed.
+        If not, the timeout didn't work, so we'll force processing to complete
+        and then the assertion against the expected ProjectData exception in
+        check_process will fail.
+        """
+        if not self.proj.status == self.expected["final_status"]:
+            (self.proj.path_proc / self.task.title()).mkdir()
+
+    def check_process(self):
+        """Special case for test_process for timed-out manual processing tasks.
+
+        With the timeout defined in set_up_proj the timer we set here should
+        NOT trigger in time, and we should get a ProjectError during processing.
+        (To handle the failure case we still start the timer, as a fail-safe.)
+        """
+        timer = threading.Timer(5, self.finish_manual)
+        timer.start()
+        with self.assertRaisesRegex(ProjectError, "timeout waiting on manual processing"):
+            self.proj.process()
+        self.assertEqual(self.proj.status, self.expected["final_status"])
+        self.assertEqual(self.proj.tasks_pending, DEFAULT_TASKS)
+        self.assertEqual(self.proj.tasks_completed, [])
+        self.assertEqual(self.proj.task_current, self.task)
+
+
+class TestProjectDataManualTimeout(TestProjectDataTimeout):
+    """ Test for single-task "manual" that doesn't finish in time.
+
+    Test that a ProjectData with a manual task specified will wait until a
+    marker appears, but will fail after waiting too long.
+    """
+
+    def set_up_vars(self):
+        self.task = "manual"
+        super().set_up_vars()
+        self.expected["final_status"] = "failed"
+
+    def test_process(self):
+        self.check_process()
+
+
 class TestProjectDataGeneious(TestProjectDataOneTask):
     """ Test for single-task "geneious".
 
@@ -697,6 +755,24 @@ class TestProjectDataGeneious(TestProjectDataOneTask):
         self.assertTrue((self.proj.path_proc / "PairedReads").exists())
         self.assertTrue((self.proj.path_proc / "ContigsGeneious").exists())
         self.assertTrue((self.proj.path_proc / "CombinedGeneious").exists())
+
+
+class TestProjectDataGeneiousTimeout(TestProjectDataTimeout):
+    """ Test for single-task "geneious" that doesn't finish in time.
+
+    Test that a ProjectData with a geneious task specified will wait until a
+    marker appears, but will fail after waiting too long.
+    """
+
+    def set_up_vars(self):
+        self.task = "geneious"
+        super().set_up_vars()
+        self.expected["final_status"] = "failed"
+        self.expected["tasks"] = ["trim", "merge", "spades", "assemble",
+                                  "geneious"] + DEFAULT_TASKS
+
+    def test_process(self):
+        self.check_process()
 
 
 class TestProjectDataMetadata(TestProjectDataOneTask):

--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -71,6 +71,17 @@ task_options:
     assemble:
       # Min length of contigs to keep in filtered Geneious-ready form
       contig_length_min: 255
+    manual:
+      # Timeout in seconds while waiting for the manual processing step.  If
+      # this is reached a ProjectError is raised, failing the processing.
+      # 60*60*24*7 = 604800 = 1 week
+      timeout: 604800
+      # Delay between checks in seconds (currently implemented as a dumb loop)
+      delta: 5
+    geneious:
+      # Same timeout and delta behavior as the manual task.
+      timeout: 604800
+      delta: 5
     email:
       # (This is for the email task specifically. For general email-sending
       # configuration see the "mailer" header below.)

--- a/umbra/task/task_geneious.py
+++ b/umbra/task/task_geneious.py
@@ -3,15 +3,23 @@
 import shutil
 import time
 from umbra import task
+from umbra.util import ProjectError
 
 class TaskGeneious(task.Task):
-    """Prepare for special-case manual processing with Geneious."""
+    """Prepare for special-case manual processing with Geneious.
+
+    The run method will wait as long as the tasks's timeout setting for the
+    directory to appear, and will raise a ProjectError otherwise.
+    """
 
     order = 101
 
     dependencies = ["assemble"]
 
     def run(self):
+        start = time.time()
+        timeout = self.config["timeout"]
+        delta = self.config["delta"]
         # Wait for a "Geneious" subdirectory to appear in the processing
         # directory.
         # Override the implicit task hiding for this specific case.  This
@@ -25,4 +33,6 @@ class TaskGeneious(task.Task):
             if path.parent != self.proj.path_proc:
                 shutil.move(str(path), str(self.proj.path_proc))
         while not (self.proj.path_proc / "Geneious").exists():
-            time.sleep(1)
+            if time.time() - start > timeout:
+                raise ProjectError("timeout waiting on manual processing")
+            time.sleep(delta)

--- a/umbra/task/task_manual.py
+++ b/umbra/task/task_manual.py
@@ -2,12 +2,22 @@
 
 import time
 from umbra import task
+from umbra.util import ProjectError
 
 class TaskManual(task.Task):
-    """Wait for a "Manual" subdir to appear in the processing directory."""
+    """Wait for a "Manual" subdir to appear in the processing directory.
+
+    The run method will wait as long as the tasks's timeout setting for the
+    directory to appear, and will raise a ProjectError otherwise.
+    """
 
     order = 100
 
     def run(self):
+        start = time.time()
+        timeout = self.config["timeout"]
+        delta = self.config["delta"]
         while not (self.proj.path_proc / "Manual").exists():
-            time.sleep(1)
+            if time.time() - start > timeout:
+                raise ProjectError("timeout waiting on manual processing")
+            time.sleep(delta)


### PR DESCRIPTION
This adds a feature to the manual and geneious tasks to fail processing if they wait too long for the expected file/directory to appear.  Fixes #60.