### PR TITLE
Better metadata parsing

### DIFF
--- a/test_umbra/data/experiments/Partials_1_1_18/metadata_emptycols.csv
+++ b/test_umbra/data/experiments/Partials_1_1_18/metadata_emptycols.csv
@@ -1,0 +1,5 @@
+Sample_Name,Project,Contacts,Tasks,,
+1086S1_01,STR,Jesse <ancon@upenn.edu>,trim,,
+1086S1_02,STR,Jesse <ancon@upenn.edu>,trim,,
+1086S1_03,Something Else,Someone <person@gmail.com>,,,
+1086S1_04,Something Else,"Someone <person@gmail.com>, Jesse Connell <ancon@upenn.edu>",,,

--- a/test_umbra/data/experiments/Partials_1_1_18/metadata_emptyrows.csv
+++ b/test_umbra/data/experiments/Partials_1_1_18/metadata_emptyrows.csv
@@ -1,0 +1,7 @@
+Sample_Name,Project,Contacts,Tasks
+1086S1_01,STR,Jesse <ancon@upenn.edu>,trim
+1086S1_02,STR,Jesse <ancon@upenn.edu>,trim
+,,,
+,,,
+1086S1_03,Something Else,Someone <person@gmail.com>,
+1086S1_04,Something Else,"Someone <person@gmail.com>, Jesse Connell <ancon@upenn.edu>",

--- a/test_umbra/test_experiment.py
+++ b/test_umbra/test_experiment.py
@@ -1,0 +1,56 @@
+"""
+Tests for experiment metadata handlers.
+"""
+
+from collections import OrderedDict
+from umbra import experiment
+from .test_common import TestBase
+
+class TestLoadMetadata(TestBase):
+    """Test basic metadata loading.
+
+    Each version of metadata.csv should provide the same list of
+    dictionaries.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.exp_path = self.paths["exp"] / "Partials_1_1_18"
+        self.expected = [ \
+            OrderedDict([
+                ('Sample_Name', '1086S1_01'), ('Project', 'STR'),
+                ('Contacts', {'Jesse': 'ancon@upenn.edu'}), ('Tasks', ['trim'])]),
+            OrderedDict([
+                ('Sample_Name', '1086S1_02'), ('Project', 'STR'),
+                ('Contacts', {'Jesse': 'ancon@upenn.edu'}), ('Tasks', ['trim'])]),
+            OrderedDict([
+                ('Sample_Name', '1086S1_03'), ('Project', 'Something Else'),
+                ('Contacts', {'Someone': 'person@gmail.com'}), ('Tasks', [])]),
+            OrderedDict([
+                ('Sample_Name', '1086S1_04'), ('Project', 'Something Else'),
+                ('Contacts', {'Someone': 'person@gmail.com', 'Jesse Connell': 'ancon@upenn.edu'}),
+                ('Tasks', [])])]
+
+    def test_load_metadata(self):
+        """Test basic metadata loading."""
+        fp_metadata = self.exp_path / "metadata.csv"
+        info = experiment.load_metadata(fp_metadata)
+        self.assertEqual(self.expected, info)
+
+    def test_load_metadata_emptyrows(self):
+        """Test metadata loading including empty rows.
+
+        Empty rows should be silently removed.
+        """
+        fp_metadata = self.exp_path / "metadata_emptyrows.csv"
+        info = experiment.load_metadata(fp_metadata)
+        self.assertEqual(self.expected, info)
+
+    def test_load_metadata_emptycols(self):
+        """Test metadata loading including empty columns.
+
+        Empty columns should be silently removed.
+        """
+        fp_metadata = self.exp_path / "metadata_emptycols.csv"
+        info = experiment.load_metadata(fp_metadata)
+        self.assertEqual(self.expected, info)

--- a/umbra/experiment.py
+++ b/umbra/experiment.py
@@ -7,7 +7,7 @@ define processing options.
 
 import csv
 import re
-from . import illumina
+from .illumina.util import load_csv
 
 def _parse_contacts(text):
     """Create a dictionary of name/email pairs from contact text.
@@ -41,7 +41,16 @@ def _parse_contacts(text):
 
 def load_metadata(path):
     """Load an Experiment metadata spreadsheet."""
-    info = illumina.util.load_csv(path, csv.DictReader)
+    info = load_csv(path, csv.DictReader)
+    # skip empty columns.  With DictReader these end up as just a stub "": ""
+    # entry.
+    for row in info:
+        if "" in row:
+            del row[""]
+    # skip empty rows
+    allempty = lambda r: set(r.values()) == set([""])
+    info = [row for row in info if not allempty(row)]
+    # parse tasks and contacts
     for row in info:
         row["Tasks"] = row["Tasks"].split()
         row["Contacts"] = _parse_contacts(row["Contacts"])


### PR DESCRIPTION
Updates to `experiment.load_metadata` to ignore empty rows and columns while parsing.  Fixes #71.