### PR TITLE
Use flow cell ID in project work_dir names

### DIFF
--- a/demo/demo_2.sh
+++ b/demo/demo_2.sh
@@ -15,7 +15,7 @@ function run_demo_2 {
 
 # Check that we get exactly the expected files.
 function test_files {
-	local dir_work=$SEQROOT/processed/2018-01-01-STR-Jesse
+	local dir_work=$SEQROOT/processed/2018-01-01-STR-Jesse-XXXXX
 	diff <((
 	for task in trim metadata package upload email; do
 		echo "$dir_work/RunDiagnostics/Logs/log_${task}.txt"

--- a/test_umbra/test_processor.py
+++ b/test_umbra/test_processor.py
@@ -50,7 +50,7 @@ class TestIlluminaProcessor(TestBase):
             # MD5 sum of the report CSV text, minus the RunPath column.  This
             # is after fulling loading the default data, but before starting
             # processing.
-            "report_md5": "52245503ae6171826d3672e26a8e4885",
+            "report_md5": "03937ca84ebc70d670f3e4b9650f4a1a",
             # The header entries we expect to see in the CSV report text.
             "report_fields": [
                 "RunId",
@@ -262,7 +262,7 @@ class TestIlluminaProcessorDuplicateRun(TestIlluminaProcessor):
         self.expected["warn_msg"] += "run-files-custom-name / "
         self.expected["warn_msg"] += "180102_M00000_0000_000000000-XXXXX"
         # There's an extra line in the report due to the duplicated run
-        self.expected["report_md5"] = "dacf2a380d1f054380a712faf8e96ed7"
+        self.expected["report_md5"] = "4aea937d44b81dfc92307999b032ce64"
 
     def test_load(self):
         # One run dir in particular is named oddly and is a duplicate of the
@@ -315,7 +315,7 @@ class TestIlluminaProcessorReadonly(TestIlluminaProcessor):
     def set_up_vars(self):
         super().set_up_vars()
         # All projects inactive in this case
-        self.expected["report_md5"] = "9f7f6c7305e12ce4baa9f09f9066b5ed"
+        self.expected["report_md5"] = "1fb1fce577c9bf7b0124ed56dac43fd6"
 
     def test_refresh(self):
         """Basic scenario for refresh(): a new run directory appears.
@@ -365,7 +365,7 @@ class TestIlluminaProcessorReportConfig(TestIlluminaProcessor):
         # used in the test below will wait, so we'll get a completed
         # ProjectData for one case.  Need an MD5 for a slightly different
         # report in that case.
-        report_md5 = "306aba28e29699cefdb82487d720be42"
+        report_md5 = "16f00124545186c2070e8adee26d1aad"
         self._watch_and_process_maybe_warning()
         # If a report was configured, it should exist
         with open(self.report_path) as f_in:

--- a/test_umbra/test_project.py
+++ b/test_umbra/test_project.py
@@ -74,11 +74,11 @@ class TestProjectData(TestBase):
         works = {
             # The date stamp is by completion date of the alignment, not
             # start date of the run (i.e., the date encoded in the Run ID).
-            "STR": "2018-01-01-STR-Jesse",
+            "STR": "2018-01-01-STR-Jesse-XXXXX",
             # The names are organized in the order presented in the
             # experiment metadata spreadsheet.  Any non-alphanumeric
             # characters are converted to _.
-            "Something Else": "2018-01-01-Something_Else-Someone-Jesse"
+            "Something Else": "2018-01-01-Something_Else-Someone-Jesse-XXXXX"
             }
         for key in works:
             self.assertEqual(works[key], self.projs[key].work_dir)
@@ -134,8 +134,8 @@ class TestProjectData(TestBase):
         md_str["status"] = "complete"
         md_str["task_output"] = {}
         md_se["task_output"] = {}
-        md_se["work_dir"] = "2018-01-01-Something_Else-Someone-Jesse"
-        md_str["work_dir"] = "2018-01-01-STR-Jesse"
+        md_se["work_dir"] = "2018-01-01-Something_Else-Someone-Jesse-XXXXX"
+        md_str["work_dir"] = "2018-01-01-STR-Jesse-XXXXX"
 
         fastq = self.paths["runs"]/"180101_M00000_0000_000000000-XXXXX/Data/Intensities/BaseCalls"
         fps = {
@@ -229,7 +229,7 @@ class TestProjectDataOneTask(TestBase):
                 "Partials_1_1_18" /
                 "metadata.csv"),
             "contacts": {"Name Lastname": "name@example.com"},
-            "work_dir": "2018-01-01-TestProject-Name",
+            "work_dir": "2018-01-01-TestProject-Name-XXXXX",
             "tasks": tasks,
             "sample_names": [
                 "1086S1_01",
@@ -894,8 +894,8 @@ class TestProjectDataEmail(TestProjectDataOneTask):
         super().set_up_vars()
         # These checksums are *after* replacing the variable temporary directory
         # path with "TMP"; see make_paths_static helper method.
-        self.expected["msg_body"] = "8cf4e595625696a3c9829fb32f5134da"
-        self.expected["msg_html"] = "0a89d75d49d366c2a893a3717e554c21"
+        self.expected["msg_body"] = "b34e1b1d387c3e9a3554b7f414545a00"
+        self.expected["msg_html"] = "1ae87b9d9f92216a287a410f99eb30c6"
         self.expected["to_addrs"] = ["Name Lastname <name@example.com>"]
 
     def test_process(self):
@@ -958,9 +958,9 @@ class TestProjectDataEmailNoName(TestProjectDataEmail):
         self.expected["to_addrs"] = ["name <name@example.com>"]
         # (Very slightly different workdir (lowercase "name") and thus download
         # URL and thus message checksums)
-        self.expected["work_dir"] = "2018-01-01-TestProject-name"
-        self.expected["msg_body"] = "b7288176f5b4d536d59a92aaf878c1b1"
-        self.expected["msg_html"] = "2feaeacc78a538e70faba27434758759"
+        self.expected["work_dir"] = "2018-01-01-TestProject-name-XXXXX"
+        self.expected["msg_body"] = "16278d694baba6f0d08f5a83a60f95cb"
+        self.expected["msg_html"] = "54b0a2cb505e97a083bd63013a75e652"
 
 
 class TestProjectDataEmailNoContacts(TestProjectDataEmail):
@@ -979,9 +979,9 @@ class TestProjectDataEmailNoContacts(TestProjectDataEmail):
         self.contacts_str = ""
         self.expected["contacts"] = {}
         self.expected["to_addrs"] = []
-        self.expected["work_dir"] = "2018-01-01-TestProject"
-        self.expected["msg_body"] = "d53d45bd2e31e906e70e3f550e535145"
-        self.expected["msg_html"] = "809352d638a6713a20892885b7dccda0"
+        self.expected["work_dir"] = "2018-01-01-TestProject-XXXXX"
+        self.expected["msg_body"] = "9bc8f2684423504363cc9d6ec7bbcdf4"
+        self.expected["msg_html"] = "6d0796877d5c60c1c5661838dc207789"
 
 
 # Other ProjectData test cases

--- a/umbra/project.py
+++ b/umbra/project.py
@@ -14,6 +14,7 @@ in the processing output directory, unexpected input data formats, etc).
 
 import traceback
 import logging
+import re
 import sys
 import warnings
 import copy
@@ -175,7 +176,9 @@ class ProjectData:
         who = [txt.split(" ")[0] for txt in who.keys()]
         who = "-".join(who)
         txt_name = slugify(who)
-        fields = [txt_date, txt_proj, txt_name]
+        txt_flowcell = re.sub("^[-0]+", "", self.alignment.run.flowcell)
+        txt_flowcell = slugify(txt_flowcell)
+        fields = [txt_date, txt_proj, txt_name, txt_flowcell]
         fields = [f for f in fields if f]
         dirname = "-".join(fields)
         if not dirname:


### PR DESCRIPTION
This adds a short form the flow cell ID extracted from each Illumina run to the project working directory names, alongside the project name, contacts, and date.  Fixes #72.