### PR TITLE
Specify minimum versions for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## dev
+
+### Fixed
+
+ * Specify minimum versions for dependencies during install ([#84])
+
+[#84]: https://github.com/ShawHahnLab/umbra/pull/84
+
 ## 0.0.2 - 2020-08-04
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ShawHahnLab/umbra",
     install_requires=[
-        "biopython",
-        "boxsdk",
+        "biopython>=1.72",
+        "boxsdk>=2.7.1",
         "pyopenssl", # required for boxsdk but not always pulled in
-        "cutadapt",
-        "pyyaml"
+        "cutadapt>=1.18",
+        "pyyaml>=3.13"
         ],
     packages=setuptools.find_packages(exclude=["test_*"]),
     include_package_data=True,


### PR DESCRIPTION
Adds minimum versions for most dependencies in `setup.py`.  Fixes #83.