### PR TITLE
Suppress duplicate log messages for skipped runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## dev
 
+### Changed
+
+ * Suppress duplicate log messages for skipped runs ([#85])
+
 ### Fixed
 
  * Specify minimum versions for dependencies during install ([#84])
 
+[#85]: https://github.com/ShawHahnLab/umbra/pull/85
 [#84]: https://github.com/ShawHahnLab/umbra/pull/84
 
 ## 0.0.2 - 2020-08-04

--- a/test_umbra/test_common.py
+++ b/test_umbra/test_common.py
@@ -3,6 +3,7 @@ Common test code shared with the real tests.  Not much to see here.
 """
 
 import unittest
+import logging
 from tempfile import TemporaryDirectory
 from distutils.dir_util import copy_tree
 from pathlib import Path
@@ -26,6 +27,22 @@ def md5(text):
     except AttributeError:
         pass
     return hashlib.md5(text).hexdigest()
+
+
+class DumbLogHandler(logging.Handler):
+    """A log handler that just stacks log records into a list."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def has_message_text(self, txt):
+        """Does some text appear in any of the records?"""
+        return True in [txt in rec.msg for rec in self.records]
+
 
 class TestBase(unittest.TestCase):
     """Some setup/teardown shared with the real test classes."""

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -322,7 +322,9 @@ class IlluminaProcessor:
                 "inactive":  set(),
                 "active":    set(),
                 "completed": set()
-                }
+                },
+            # just a tracker to avoid re-logging skipped runs
+            "runs_skipped": set()
             }
         return seqinfo
 
@@ -363,10 +365,14 @@ class IlluminaProcessor:
         # Now, check each threshold if it was specified.  Careful to check for
         # None here because a literal zero should be taken as its own meaning.
         if min_age is not None and (time_now - time_change < min_age):
-            LOGGER.info("skipping run; timestamp too new:.../%s", run_dir.name)
+            if run not in self.seqinfo["runs_skipped"]:
+                LOGGER.info("skipping run; timestamp too new:.../%s", run_dir.name)
+                self.seqinfo["runs_skipped"].add(run)
             return run
         if max_age is not None and (time_now - time_change > max_age):
-            LOGGER.info("skipping run; timestamp too old:.../%s", run_dir.name)
+            if run not in self.seqinfo["runs_skipped"]:
+                LOGGER.info("skipping run; timestamp too old:.../%s", run_dir.name)
+                self.seqinfo["runs_skipped"].add(run)
             return run
         # pylint: disable=broad-except
         try:


### PR DESCRIPTION
Runs that are skipped for timestamp reasons (either too old or too new) are now only logged once, rather than every time the processor loops over them.  Fixes #81.