### PR TITLE
Use Unix-style line endings in report CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### Changed
 
+ * Use Unix-style line endings in report CSV ([#86])
  * Suppress duplicate log messages for skipped runs ([#85])
 
 ### Fixed
 
  * Specify minimum versions for dependencies during install ([#84])
 
+[#86]: https://github.com/ShawHahnLab/umbra/pull/86
 [#85]: https://github.com/ShawHahnLab/umbra/pull/85
 [#84]: https://github.com/ShawHahnLab/umbra/pull/84
 

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -284,7 +284,8 @@ class IlluminaProcessor:
         length will be truncated and displayed with "..."  Set to 0 for no
         maximum."""
         entries = self.create_report()
-        writer = csv.DictWriter(out_file, IlluminaProcessor.REPORT_FIELDS)
+        writer = csv.DictWriter(
+            out_file, lineterminator="\n", fieldnames=IlluminaProcessor.REPORT_FIELDS)
         writer.writeheader()
         for entry in entries:
             entry2 = entry


### PR DESCRIPTION
Switch from the default Windows-style line endings for the report CSV to Unix-style.  Fixes #79.