### PR TITLE
Ignore Box network log message at level INFO or below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
 
 ### Fixed
 
+ * Suppress excessive logging for Box file uploads ([#89])
  * Specify minimum versions for dependencies during install ([#84])
 
+[#87]: https://github.com/ShawHahnLab/umbra/pull/89
 [#87]: https://github.com/ShawHahnLab/umbra/pull/87
 [#86]: https://github.com/ShawHahnLab/umbra/pull/86
 [#85]: https://github.com/ShawHahnLab/umbra/pull/85

--- a/umbra/box_uploader.py
+++ b/umbra/box_uploader.py
@@ -17,6 +17,11 @@ from .util import yaml_load
 
 LOGGER = logging.getLogger(__name__)
 
+# Box logs the entire (!) uploaded file at level INFO.
+# Let's ignore INFO and below.
+__BOXLOGGER = logging.getLogger("boxsdk.network.default_network")
+__BOXLOGGER.setLevel(logging.WARNING)
+
 class BoxUploader:
     """A simple Box API interface to upload files to one directory.
 


### PR DESCRIPTION
Configures the logger for `boxsdk.network.default_network` to level WARNING.  This avoids gigantic INFO-level log messages that contain uploaded file contents.  Fixes #88.