### PR TITLE
Version 0.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ script:
   # Ensure the installation process created a viable script for the entry
   # point.
   - umbra -h
+  # Check the version argument.
+  - umbra --version
   # Try a dry run installation.
   - sudo -E $(which umbra) --action install --dry-run
   # Try a live installation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## dev
 
+### Changed
+
+ * Suppress duplicate log messages for skipped runs ([#85])
+
 ### Fixed
 
  * Specify minimum versions for dependencies during install ([#84])
 
+[#85]: https://github.com/ShawHahnLab/umbra/pull/85
 [#84]: https://github.com/ShawHahnLab/umbra/pull/84
 
 ## 0.0.2 - 2020-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
 
 ### Fixed
 
+ * Suppress excessive logging for Box file uploads ([#89])
  * Specify minimum versions for dependencies during install ([#84])
 
+[#87]: https://github.com/ShawHahnLab/umbra/pull/89
 [#87]: https://github.com/ShawHahnLab/umbra/pull/87
 [#86]: https://github.com/ShawHahnLab/umbra/pull/86
 [#85]: https://github.com/ShawHahnLab/umbra/pull/85

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## dev
+
+### Fixed
+
+ * Specify minimum versions for dependencies during install ([#84])
+
+[#84]: https://github.com/ShawHahnLab/umbra/pull/84
+
 ## 0.0.2 - 2020-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### Changed
 
+ * Use Unix-style line endings in report CSV ([#86])
  * Suppress duplicate log messages for skipped runs ([#85])
 
 ### Fixed
 
  * Specify minimum versions for dependencies during install ([#84])
 
+[#86]: https://github.com/ShawHahnLab/umbra/pull/86
 [#85]: https://github.com/ShawHahnLab/umbra/pull/85
 [#84]: https://github.com/ShawHahnLab/umbra/pull/84
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## dev
 
+### Added
+
+ * `--version` argument to command-line interface ([#87])
+
 ### Changed
 
  * Use Unix-style line endings in report CSV ([#86])
@@ -11,6 +15,7 @@
 
  * Specify minimum versions for dependencies during install ([#84])
 
+[#87]: https://github.com/ShawHahnLab/umbra/pull/87
 [#86]: https://github.com/ShawHahnLab/umbra/pull/86
 [#85]: https://github.com/ShawHahnLab/umbra/pull/85
 [#84]: https://github.com/ShawHahnLab/umbra/pull/84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## dev
+## 0.0.3 - 2020-08-19
 
 ### Added
 

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ShawHahnLab/umbra",
     install_requires=[
-        "biopython",
-        "boxsdk",
+        "biopython>=1.72",
+        "boxsdk>=2.7.1",
         "pyopenssl", # required for boxsdk but not always pulled in
-        "cutadapt",
-        "pyyaml"
+        "cutadapt>=1.18",
+        "pyyaml>=3.13"
         ],
     packages=setuptools.find_packages(exclude=["test_*"]),
     include_package_data=True,

--- a/test_umbra/test_common.py
+++ b/test_umbra/test_common.py
@@ -3,6 +3,7 @@ Common test code shared with the real tests.  Not much to see here.
 """
 
 import unittest
+import logging
 from tempfile import TemporaryDirectory
 from distutils.dir_util import copy_tree
 from pathlib import Path
@@ -26,6 +27,22 @@ def md5(text):
     except AttributeError:
         pass
     return hashlib.md5(text).hexdigest()
+
+
+class DumbLogHandler(logging.Handler):
+    """A log handler that just stacks log records into a list."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def has_message_text(self, txt):
+        """Does some text appear in any of the records?"""
+        return True in [txt in rec.msg for rec in self.records]
+
 
 class TestBase(unittest.TestCase):
     """Some setup/teardown shared with the real test classes."""

--- a/umbra/__main__.py
+++ b/umbra/__main__.py
@@ -10,6 +10,7 @@ import logging
 from .processor import IlluminaProcessor
 from . import config
 from . import install
+from . import __version__ as VERSION
 
 DOCS = {}
 DOCS["description"] = "Process Illumina runs."
@@ -37,6 +38,8 @@ PARSER.add_argument("-c", "--config", help="path to configuration file")
 PARSER.add_argument("-a", "--action", default="report",
                     help="program action (default: %(default)s)",
                     choices=["process", "report", "install"])
+PARSER.add_argument("-V", "--version", action="store_true",
+                    help="Print installed version of umbra package")
 PARSER.add_argument("-v", "--verbose", action="count", default=0,
                     help="Increment log verbosity")
 PARSER.add_argument("-q", "--quiet", action="count", default=0,
@@ -84,7 +87,9 @@ def main(args_raw=None):
             LOGGER.setLevel(newlevel)
             _setup_log(args.verbose, args.quiet)
         action_args = conf.get(args.action, {})
-        if args.action == "process":
+        if args.version:
+            print(VERSION or "Not installed")
+        elif args.action == "process":
             proc = IlluminaProcessor(conf["paths"]["root"], conf)
             proc.watch_and_process(**action_args)
         elif args.action == "report":

--- a/umbra/box_uploader.py
+++ b/umbra/box_uploader.py
@@ -17,6 +17,11 @@ from .util import yaml_load
 
 LOGGER = logging.getLogger(__name__)
 
+# Box logs the entire (!) uploaded file at level INFO.
+# Let's ignore INFO and below.
+__BOXLOGGER = logging.getLogger("boxsdk.network.default_network")
+__BOXLOGGER.setLevel(logging.WARNING)
+
 class BoxUploader:
     """A simple Box API interface to upload files to one directory.
 

--- a/umbra/data/config.yml
+++ b/umbra/data/config.yml
@@ -23,6 +23,11 @@ nthreads_per_project: 1
 # Configure as a number of seconds from the present time.  This will be
 # separately applied to the Alignment directories within each run directory as
 # well.
+# NOTE: This is implemented using the timestamp on each run directory, so
+# anything that updates the timestamp can delay processing, potentially
+# indefinitely.  (This was our experience with a MiniSeq that keeps touching
+# its most recently created run directory until it moves onto the next run or
+# is rebooted.)
 min_age: null
 # How about run directories older than a certain age?
 max_age: null

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -322,7 +322,9 @@ class IlluminaProcessor:
                 "inactive":  set(),
                 "active":    set(),
                 "completed": set()
-                }
+                },
+            # just a tracker to avoid re-logging skipped runs
+            "runs_skipped": set()
             }
         return seqinfo
 
@@ -363,10 +365,14 @@ class IlluminaProcessor:
         # Now, check each threshold if it was specified.  Careful to check for
         # None here because a literal zero should be taken as its own meaning.
         if min_age is not None and (time_now - time_change < min_age):
-            LOGGER.info("skipping run; timestamp too new:.../%s", run_dir.name)
+            if run not in self.seqinfo["runs_skipped"]:
+                LOGGER.info("skipping run; timestamp too new:.../%s", run_dir.name)
+                self.seqinfo["runs_skipped"].add(run)
             return run
         if max_age is not None and (time_now - time_change > max_age):
-            LOGGER.info("skipping run; timestamp too old:.../%s", run_dir.name)
+            if run not in self.seqinfo["runs_skipped"]:
+                LOGGER.info("skipping run; timestamp too old:.../%s", run_dir.name)
+                self.seqinfo["runs_skipped"].add(run)
             return run
         # pylint: disable=broad-except
         try:

--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -284,7 +284,8 @@ class IlluminaProcessor:
         length will be truncated and displayed with "..."  Set to 0 for no
         maximum."""
         entries = self.create_report()
-        writer = csv.DictWriter(out_file, IlluminaProcessor.REPORT_FIELDS)
+        writer = csv.DictWriter(
+            out_file, lineterminator="\n", fieldnames=IlluminaProcessor.REPORT_FIELDS)
         writer.writeheader()
         for entry in entries:
             entry2 = entry


### PR DESCRIPTION
### Added

 * `--version` argument to command-line interface ([#87])

### Changed

 * Use Unix-style line endings in report CSV ([#86])
 * Suppress duplicate log messages for skipped runs ([#85])

### Fixed

 * Suppress excessive logging for Box file uploads ([#89])
 * Specify minimum versions for dependencies during install ([#84])

[#87]: https://github.com/ShawHahnLab/umbra/pull/89
[#87]: https://github.com/ShawHahnLab/umbra/pull/87
[#86]: https://github.com/ShawHahnLab/umbra/pull/86
[#85]: https://github.com/ShawHahnLab/umbra/pull/85
[#84]: https://github.com/ShawHahnLab/umbra/pull/84