### PR TITLE
Parse tasks as lowercase in experiment metadata.csv files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Changed
 
+ * Always read task names as lowercase when parsing metadata.csv files ([#95])
  * Parse fastq.gz files per sample from disk rather than predicting from sample
    name alone ([#94])
 
+[#95]: https://github.com/ShawHahnLab/umbra/pull/95
 [#94]: https://github.com/ShawHahnLab/umbra/pull/94
 
 ## 0.0.3 - 2020-08-19

--- a/test_umbra/data/experiments/Partials_1_1_18/metadata_caps.csv
+++ b/test_umbra/data/experiments/Partials_1_1_18/metadata_caps.csv
@@ -1,0 +1,5 @@
+Sample_Name,Project,Contacts,Tasks
+1086S1_01,STR,Jesse <ancon@upenn.edu>,Trim
+1086S1_02,STR,Jesse <ancon@upenn.edu>,TRIM
+1086S1_03,Something Else,Someone <person@gmail.com>,
+1086S1_04,Something Else,"Someone <person@gmail.com>, Jesse Connell <ancon@upenn.edu>",

--- a/test_umbra/test_experiment.py
+++ b/test_umbra/test_experiment.py
@@ -37,6 +37,12 @@ class TestLoadMetadata(TestBase):
         info = experiment.load_metadata(fp_metadata)
         self.assertEqual(self.expected, info)
 
+    def test_load_metadata_caps(self):
+        """Test metadata loading with capital letters in the Tasks column."""
+        fp_metadata = self.exp_path / "metadata_caps.csv"
+        info = experiment.load_metadata(fp_metadata)
+        self.assertEqual(self.expected, info)
+
     def test_load_metadata_emptyrows(self):
         """Test metadata loading including empty rows.
 

--- a/umbra/experiment.py
+++ b/umbra/experiment.py
@@ -52,6 +52,6 @@ def load_metadata(path):
     info = [row for row in info if not allempty(row)]
     # parse tasks and contacts
     for row in info:
-        row["Tasks"] = row["Tasks"].split()
+        row["Tasks"] = [task.lower() for task in row["Tasks"].split()]
         row["Contacts"] = _parse_contacts(row["Contacts"])
     return info


### PR DESCRIPTION
Updates load_metadata to convert task names to all-lowercase.  Fixes #92.