### PR TITLE
Fix contig labeling in task_assemble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@
 
 ### Fixed
 
- * Corrected parsing for Illumina's Checkpoint.txt files to work with
+ * Correct parsing of contig numbers in task_assemble to include all digits
+   ([#100])
+ * Correct parsing for Illumina's Checkpoint.txt files to work with
    incomplete alignment outputs ([#97])
 
+[#100]: https://github.com/ShawHahnLab/umbra/pull/100
 [#99]: https://github.com/ShawHahnLab/umbra/pull/99
 [#97]: https://github.com/ShawHahnLab/umbra/pull/97
 [#95]: https://github.com/ShawHahnLab/umbra/pull/95

--- a/test_umbra/test_task/test_task_assemble.py
+++ b/test_umbra/test_task/test_task_assemble.py
@@ -141,15 +141,3 @@ class TestTaskAssembleManyContigs(TestTaskAssemble):
             }
         # pylint: disable=no-member
         self.thing = task.TaskAssemble({}, self.proj)
-
-    @unittest.expectedFailure
-    def test_run(self):
-        """Failing due to bug in contig re-labeling."""
-        self.thing.run()
-        self.check_run_results()
-
-    @unittest.expectedFailure
-    def test_runwrapper(self):
-        """Failing due to bug in contig re-labeling."""
-        self.thing.runwrapper()
-        self.check_run_results()

--- a/umbra/task/task_assemble.py
+++ b/umbra/task/task_assemble.py
@@ -57,7 +57,7 @@ class TaskAssemble(task.Task):
             for rec in SeqIO.parse(f_in, "fasta"):
                 if len(rec.seq) > self.config["contig_length_min"]:
                     rec.letter_annotations["phred_quality"] = [40]*len(rec.seq)
-                    match = re.match("^NODE_([0-9])+_.*", rec.id)
+                    match = re.match("^NODE_([0-9]+)_.*", rec.id)
                     contig_num = match.group(1)
                     rec.id = "%s-contig_%s" % (sample_prefix, contig_num)
                     rec.description = ""


### PR DESCRIPTION
Corrects a mistake in a regular expression capture group that was only capturing the first digit of contig numbers. Fixes #98.