### PR TITLE
Add error property to Alignment class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## dev
+
+### Added
+
+ * `error` property for `illumina.alignment.Alignment` class ([#104])
+
+[#104]: https://github.com/ShawHahnLab/umbra/pull/104
+
 ## 0.0.4 - 2020-09-08
 
 ### Added

--- a/test_umbra/test_illumina/test_alignment.py
+++ b/test_umbra/test_illumina/test_alignment.py
@@ -132,7 +132,7 @@ class TestAlignment(unittest.TestCase):
         # The values are sample paths
         vals = [aln.sample_paths_for_num(n) for n in aln.sample_numbers]
         keys = aln.sample_names
-        spaths_exp = {k: v for k, v in zip(keys, vals)}
+        spaths_exp = dict(zip(keys, vals))
         self.assertEqual(spaths, spaths_exp)
 
     def test_refresh(self):
@@ -201,7 +201,7 @@ class TestAlignmentFilesMissing(TestAlignment):
         nums = self.alignment.sample_numbers
         vals = [self.alignment.sample_paths_for_num(n, False) for n in nums]
         keys = self.alignment.sample_names
-        spaths_exp = {k: v for k, v in zip(keys, vals)}
+        spaths_exp = dict(zip(keys, vals))
         self.assertEqual(spaths, spaths_exp)
 
 

--- a/test_umbra/test_illumina/test_alignment.py
+++ b/test_umbra/test_illumina/test_alignment.py
@@ -79,6 +79,11 @@ class TestAlignment(unittest.TestCase):
         """
         self.assertIsNone(self.alignment.index)
 
+    def test_error(self):
+        """What's the error message for the alignment?"""
+        # In a successful alignment there isn't one.
+        self.assertIsNone(self.alignment.error)
+
     def test_complete(self):
         """Is an Alignment complete?"""
         # An alignment is complete if Checkpoint exists and is 3, is not
@@ -221,6 +226,27 @@ class TestAlignmentMiniSeq(TestAlignment):
         self.expected["paths"]["sample_sheet"] = subpath / "SampleSheetUsed.csv"
         self.expected["paths"]["fastq"] = subpath / "Fastq"
         self.expected["paths"]["checkpoint"] = subpath / "Checkpoint.txt"
+
+
+class TestAlignmentErrored(TestAlignment):
+    """Test an Alignment with an error."""
+
+    def set_up_alignment(self):
+        xml_fp = self.paths["alignment"] / "CompletedJobInfo.xml"
+        xml_fp.chmod(0o660)
+        # insert an error into the XML
+        with open(xml_fp) as f_in:
+            data = list(f_in)
+        with open(xml_fp, "wt") as f_out:
+            for line in data:
+                if line == "</AnalysisJobInfo>\n":
+                    line = "<Error>whoops</Error></AnalysisJobInfo>\n"
+                f_out.write(line)
+        super().set_up_alignment()
+
+    def test_error(self):
+        """What's the error message for the alignment?"""
+        self.assertEqual(self.alignment.error, "whoops")
 
 
 if __name__ == '__main__':

--- a/umbra/illumina/alignment.py
+++ b/umbra/illumina/alignment.py
@@ -85,6 +85,18 @@ class Alignment:
         return None
 
     @property
+    def error(self):
+        """Text of the Error entry in CompletedJobInfo.xml
+
+        None if there is no XML file or Error entry.
+        """
+        if self.completed_job_info:
+            elem = self.completed_job_info.find("Error")
+            if elem is not None:
+                return elem.text
+        return None
+
+    @property
     def complete(self):
         """Is the alignment complete?"""
         # This is true when the checkpoint file reaches stage 3 or whatever


### PR DESCRIPTION
This adds an `error` property to the Alignment class that pulls the error text, if any, from the CompletedJobInfo.xml file (again, if any).  This is independent of the `completed` property, since an alignment may or may not be completed and may or may not have an error.