### PR TITLE
Call alignment completion callback only when run is complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
-# According to https://docs.travis-ci.com/user/languages/python/ 3.7 does not
-# currently work on Travis.  3.5 does but this package would need
-# modifications.
 python:
-  - "3.6"
+  - "3.7"
 before_install:
   - sudo apt-get update && sudo apt-get install systemd
 # Based on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
 
 ### Fixed
 
+ * Only process an alignment when its containing run is marked complete
+   ([#108])
  * Handle non-unicode characters in CSV files ([#105])
 
+[#108]: https://github.com/ShawHahnLab/umbra/pull/108
 [#106]: https://github.com/ShawHahnLab/umbra/pull/106
 [#105]: https://github.com/ShawHahnLab/umbra/pull/105
 [#104]: https://github.com/ShawHahnLab/umbra/pull/104

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
         "cutadapt>=1.18",
         "pyyaml>=3.13"
         ],
+    python_requires='>=3.7',
     packages=setuptools.find_packages(exclude=["test_*"]),
     include_package_data=True,
     entry_points={'console_scripts': [

--- a/umbra/illumina/alignment.py
+++ b/umbra/illumina/alignment.py
@@ -64,7 +64,7 @@ class Alignment:
         If the alignment has just completed, and a callback function was
         provided during instantiation, call it."""
         self.__path_attrs = load_sample_filenames(self.paths["fastq"])
-        if not self.complete:
+        if (self.run is None or self.run.complete) and not self.complete:
             self.checkpoint = load_checkpoint(self.paths["checkpoint"])
             if self.complete and self.completion_callback:
                 self.completion_callback(self)


### PR DESCRIPTION
This clarifies the obscure edge case of an alignment that is shown to be complete on disk *before* its containing run.  The alignment completion status is reported the same as always, but its completion callback will now only be called when the alignment and run both report that they are complete. Fixes #107.

This also bumps the Python requirement from 3.6 to 3.7 to [make numpy happy again](https://travis-ci.org/github/ShawHahnLab/umbra/builds/748217800).