### PR TITLE
Handle non-unicode characters in TaskMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
 
  * Only process an alignment when its containing run is marked complete
    ([#108])
- * Handle non-unicode characters in CSV files ([#105])
+ * Handle non-unicode characters in CSV files ([#105], [#115])
 
+[#115]: https://github.com/ShawHahnLab/umbra/pull/115
 [#111]: https://github.com/ShawHahnLab/umbra/pull/111
 [#108]: https://github.com/ShawHahnLab/umbra/pull/108
 [#106]: https://github.com/ShawHahnLab/umbra/pull/106

--- a/test_umbra/test_task/test_task_metadata.py
+++ b/test_umbra/test_task/test_task_metadata.py
@@ -38,6 +38,11 @@ class TestTaskMetadata(test_task.TestTask):
         summary_expected = "\n".join(summary_expected)
         self.assertEqual(self.thing.summary, summary_expected)
 
+    # I can think of two test cases here, a simple metadata.csv case and one
+    # with strange characters like that tested in TestProjectDataFromAlignment's
+    # test_from_alignment_iso8859.  Ideally the behavior for non-unicode text
+    # would be centralized but it's currently defined in both ProjectData and
+    # TaskMetadata independently.
     def test_run(self):
         self.skipTest("not yet implemented")
 

--- a/umbra/task/task_metadata.py
+++ b/umbra/task/task_metadata.py
@@ -25,7 +25,8 @@ class TaskMetadata(task.Task):
         # ignore anything non-unicode here since it should have already been
         # complained about when first parsed.  (There's also the already-parsed
         # data structure within self.proj but the original line-by-line CSV is
-        # already gone at that point.)
+        # already gone at that point.)  Ideally the non_unicode behavior would
+        # be defined in one place instead of both here and in ProjectData.
         data = load_csv(self.proj.exp_path, csv.DictReader, non_unicode="strip")
         with open(path_md_out, "w") as f_out:
             # Write out the experiment spreadsheet but only include our rows


### PR DESCRIPTION
Updates `TaskMetadata.run` to remove non-unicode characters as `ProjectData.from_alignment` does.  Fixes #114.