### PR TITLE
Update Python req to >=3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             export PATH="$HOME/miniconda/bin:$PATH"
             conda config --set always_yes yes --set changeps1 no
             conda update -q conda
-            conda create -q -n test-environment -c bioconda spades python=3.7
+            conda create -q -n test-environment -c bioconda spades python=3.8
       - save_cache:
           key: conda-{{ checksum "setup.py" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - conda-{{ checksum "setup.py" }}
+            - conda-{{ checksum "setup.py" }}-py38
       - run:
           name: Set up conda environemnt
           working_directory: ..
@@ -33,7 +33,7 @@ jobs:
             conda update -q conda
             conda create -q -n test-environment -c bioconda spades python=3.8
       - save_cache:
-          key: conda-{{ checksum "setup.py" }}
+          key: conda-{{ checksum "setup.py" }}-py38
           paths:
             - ../miniconda
       - run:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "cutadapt>=1.18",
         "pyyaml>=3.13"
         ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     packages=setuptools.find_packages(exclude=["test_*"]),
     include_package_data=True,
     entry_points={'console_scripts': [


### PR DESCRIPTION
Required for the numpy that gets installed (but not pulled in automatically for some reason?) so I'm setting it explicitly.