### PR TITLE
Update alignment setup and refresh handling for newer Illumina behavior

### DIFF
--- a/umbra/processor.py
+++ b/umbra/processor.py
@@ -442,6 +442,7 @@ class IlluminaProcessor:
         Any projects with previously-created metadata on disk will be marked
         inactive and not processed."""
         LOGGER.debug("proccesing new alignment: %s", aln.path)
+        LOGGER.debug("alignment paths for %s: %s", aln.path, aln.paths)
         projs = project.ProjectData.from_alignment(
             alignment=aln,
             path_exp=self.paths["exp"],


### PR DESCRIPTION
These were supposed to be short-term workarounds circa 2021 but we've been using them ever since.  The key changes:

 * wait up to 10 minutes during Alignment refresh for .fastq.gz files to appear
 * catch permission errors during initial Alignment object setup and re-raise as `ValueError` so the alignment is skipped (see `Run._alignment_setup`) and-rechecked later on