### PR TITLE
Handle leading and trailing whitespace in Contact column of experiment metadata CSV files

### DIFF
--- a/test_umbra/data/test_experiment/TestLoadMetadataContactsWhitespace/metadata.csv
+++ b/test_umbra/data/test_experiment/TestLoadMetadataContactsWhitespace/metadata.csv
@@ -1,0 +1,5 @@
+Sample_Name,Project,Contacts,Tasks
+1086S1_01,STR,Jesse <ancon@upenn.edu>,trim
+1086S1_02,STR, Jesse <ancon@upenn.edu>,trim
+1086S1_03,Something Else, ,
+1086S1_04,Something Else, ,

--- a/test_umbra/test_experiment.py
+++ b/test_umbra/test_experiment.py
@@ -47,6 +47,32 @@ class TestLoadMetadataEmptycols(TestLoadMetadata):
     Empty columns should be silently removed.
     """
 
+class TestLoadMetadataContactsWhitespace(TestLoadMetadata):
+    """Test metadata loading including leading/trailing whitespace in Contacts.
+
+    The whitespace should be stripped out, and all-whitespace entries should be
+    equivalent to rows with no contact info supplied.
+    """
+
+    def test_load_metadata(self):
+        fp_metadata = self.path / "metadata.csv"
+        info = experiment.load_metadata(fp_metadata)
+        expected = [ \
+            OrderedDict([
+                ('Sample_Name', '1086S1_01'), ('Project', 'STR'),
+                ('Contacts', {'Jesse': 'ancon@upenn.edu'}), ('Tasks', ['trim'])]),
+            OrderedDict([
+                ('Sample_Name', '1086S1_02'), ('Project', 'STR'),
+                ('Contacts', {'Jesse': 'ancon@upenn.edu'}), ('Tasks', ['trim'])]),
+            OrderedDict([
+                ('Sample_Name', '1086S1_03'), ('Project', 'Something Else'),
+                ('Contacts', {}), ('Tasks', [])]),
+            OrderedDict([
+                ('Sample_Name', '1086S1_04'), ('Project', 'Something Else'),
+                ('Contacts', {}),
+                ('Tasks', [])])]
+        self.assertEqual(expected, info)
+
 
 class TestLoadMetadataISO8859(TestLoadMetadata):
     """Test metadata loading with non-unicode file.

--- a/umbra/experiment.py
+++ b/umbra/experiment.py
@@ -18,7 +18,7 @@ def _parse_contacts(text):
     {'Name': 'email@example.com', 'Someone Else': 'user@site.gov'}
     """
 
-    chunks = re.split("[,;]+", text)
+    chunks = re.split("[,;]+", text.strip())
     contacts = {}
     for chunk in chunks:
         if not chunk:


### PR DESCRIPTION
All-whitespace strings in the Contact column of an experiment metadata CSV file would previously crash the contact info parsing, so this now strips leading and trailing whitespace (which ends up treating those cases as empty strings, and so, as missing contact info).  Fixes #124.