### PR TITLE
Handle missing Sample_Names column in sample sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@
 
 ### Fixed
 
+ * No longer crash when encountering runs missing the `Sample_Name` column in
+   their sample sheets ([#129])
  * Ignore leading and/or trailing whitespace in the Contact column when loading
    an experiment metadata CSV, so all-whitespace entries are now treated as
    missing contact info rather than causing a crash during parsing ([#128])
 
+[#129]: https://github.com/ShawHahnLab/umbra/pull/129
 [#128]: https://github.com/ShawHahnLab/umbra/pull/128
 [#127]: https://github.com/ShawHahnLab/umbra/pull/127
 [#121]: https://github.com/ShawHahnLab/umbra/pull/121

--- a/test_umbra/test_illumina/test_alignment.py
+++ b/test_umbra/test_illumina/test_alignment.py
@@ -60,6 +60,11 @@ class TestAlignment(TestBase):
     def test_sample_names(self):
         """Test existence (not content, currently) of sample names."""
         self.assertEqual(len(self.aln.sample_names), 4)
+        # Even if the sample sheet didn't supply a Sample_Name column it should
+        # still return a list for the names, just full of None
+        for row in self.aln.sample_sheet["Data"]:
+            del row["Sample_Name"]
+        self.assertEqual(self.aln.sample_names, [None] * 4)
 
     def test_samples(self):
         """Test for consistency of sample metadata with sample sheet."""

--- a/umbra/illumina/alignment.py
+++ b/umbra/illumina/alignment.py
@@ -155,7 +155,7 @@ class Alignment:
     @property
     def sample_names(self):
         """Ordered list of all sample names."""
-        names = [row["Sample_Name"] for row in self.sample_sheet["Data"]]
+        names = [row.get("Sample_Name") for row in self.sample_sheet["Data"]]
         return names
 
     @property


### PR DESCRIPTION
Previously, trying to access an Alignment's `sample_names` property would crash if the underlying sample sheet didn't have the expected `Sample_Names` column in the data section.  Now that property just returns `None` across all samples in that situation.  Fixes #126.  (This sidesteps the larger issue of how to handle runs whose samples can't be referenced by a set of unique sample names, but at least this way things don't crash.)