### PR TITLE
Support newer RTAComplete.txt format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## dev
+
+### Added
+
+ * `illumina.util.load_rta_complete` now handles the syntax used by NextSeq and
+   MiSeq i100 Plus software for RTAComplete.txt ([#132])
+
+[#132]: https://github.com/ShawHahnLab/umbra/pull/132
+
 ## 0.0.6 - 2025-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## dev
+## 0.0.6 - 2025-07-10
 
 ### Added
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="umbra",
-    version="0.0.5",
+    version="0.0.6",
     description="A package and executable for handling Illumina sequencing runs",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/umbra/illumina/util.py
+++ b/umbra/illumina/util.py
@@ -121,13 +121,20 @@ def load_rta_complete(path):
     """Parse an RTAComplete.txt file.
 
     Creates a dictionary with the Date and Illumina Real-Time Analysis
-    software version.  This file should exist for a run if real-time analysis
-    that does basecalling and generates BCL files has finished.
+    software version, if present.  This file should exist for a run if
+    real-time analysis that does basecalling and generates BCL files has
+    finished.
     """
     try:
         data = load_csv(path)[0]
     except (FileNotFoundError, IndexError):
         return None
+    # Newer Illumina software (on NextSeq, MiSeq i100 Plus, others?) just puts
+    # a single space in this file and nothing else.  As a stopgap (since we
+    # currently use this to define the date part of the work directory names in
+    # Project) we'll just use the modification time of the file.
+    if data == [" "]:
+        return {"Date": datetime.datetime.fromtimestamp(Path(path).stat().st_mtime)}
     date_pad = lambda txt: "/".join([x.zfill(2) for x in txt.split("/")])
     time_pad = lambda txt: ":".join([x.zfill(2) for x in txt.split(":")])
     # MiniSeq (RTA 2x?)


### PR DESCRIPTION
Adds support for what evidently is the newer format for RTAComplete.txt files we see for our MiSeq i100 Plus and NextSeq sequencers.  Fixes #131.