### PR TITLE
Test and support Python from 3.9 to 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ version: 2.1
 
 jobs:
   main:
+    parameters:
+      python-version:
+        type: string
     # Using a machine executor instead of a docker image because we need to
     # interact with systemd to run a full test, which doesn't play nicely with
     # docker.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ jobs:
             export PATH="$HOME/miniconda/bin:$PATH"
             conda config --set always_yes yes --set changeps1 no
             conda update -q conda
-            conda env update --file project/.circleci/env.yml
+            sed 's/^  - python=.*/  - python=<< python-version >>/' < project/.circleci/env.yml > env.yml
+            conda env update --file env.yml
       - save_cache:
           key: conda-{{ checksum "setup.py" }}-{{ checksum "/home/circleci/project/.circleci/env.yml" }}
           paths:
@@ -125,4 +126,7 @@ jobs:
 workflows:
   main:
     jobs:
-      - main
+      - main:
+          matrix:
+            parameters:
+              python-versions: [3.9, 3.10, 3.11, 3.12]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,4 +132,4 @@ workflows:
       - main:
           matrix:
             parameters:
-              python-version: [3.9, 3.10, 3.11, 3.12]
+              python-version: ["3.9", "3.10", "3.11", "3.12"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             export PATH="$HOME/miniconda/bin:$PATH"
             conda config --set always_yes yes --set changeps1 no
             conda update -q conda
-            sed 's/^  - python=.*/  - python=<< python-version >>/' < project/.circleci/env.yml > env.yml
+            sed 's/^  - python=.*/  - python=<< parameters.python-version >>/' < project/.circleci/env.yml > env.yml
             conda env update --file env.yml
       - save_cache:
           key: conda-{{ checksum "setup.py" }}-{{ checksum "/home/circleci/project/.circleci/env.yml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       # Initial setup
       - checkout
       - restore_cache:
-          key: conda-{{ checksum "setup.py" }}-{{ checksum "/home/circleci/project/.circleci/env.yml" }}
+          key: conda-{{ checksum "setup.py" }}-{{ checksum "/home/circleci/project/.circleci/env.yml" }}-python<< parameters.python-version >>
       - run:
           name: Set up conda environment
           working_directory: ..
@@ -36,7 +36,7 @@ jobs:
             sed 's/^  - python=.*/  - python=<< parameters.python-version >>/' < project/.circleci/env.yml > env.yml
             conda env update --file env.yml
       - save_cache:
-          key: conda-{{ checksum "setup.py" }}-{{ checksum "/home/circleci/project/.circleci/env.yml" }}
+          key: conda-{{ checksum "setup.py" }}-{{ checksum "/home/circleci/project/.circleci/env.yml" }}-python<< parameters.python-version >>
           paths:
             - ../miniconda
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,4 +132,4 @@ workflows:
       - main:
           matrix:
             parameters:
-              python-version: ["3.9", "3.10", "3.11", "3.12"]
+              python-version: ["3.9", "3.10", "3.11"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,4 +129,4 @@ workflows:
       - main:
           matrix:
             parameters:
-              python-versions: [3.9, 3.10, 3.11, 3.12]
+              python-version: [3.9, 3.10, 3.11, 3.12]

--- a/.circleci/env.yml
+++ b/.circleci/env.yml
@@ -8,3 +8,6 @@ dependencies:
   - pear>=0.9.6,<1
   - spades>=3.13,<4
   - pip
+    # will be needed for unit tests (TestMailer) for Python 3.12 onward, as
+    # smtpd is removed from the standard library
+  - conda-forge::aiosmtpd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## dev
+
+### Changed
+
+ * Python from 3.9 to 3.11 is supported ([#140])
+
+[#140]: https://github.com/ShawHahnLab/umbra/pull/140
+
 ## 0.0.7 - 2025-07-11
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "cutadapt>=4.0",
         "pyyaml>=5.1"
         ],
-    python_requires='>=3.9,<3.13',
+    python_requires='>=3.9,<3.12',
     packages=setuptools.find_packages(exclude=["test_*"]),
     include_package_data=True,
     entry_points={'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "cutadapt>=4.0",
         "pyyaml>=5.1"
         ],
-    python_requires='>=3.9',
+    python_requires='>=3.9,<=3.12',
     packages=setuptools.find_packages(exclude=["test_*"]),
     include_package_data=True,
     entry_points={'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "cutadapt>=4.0",
         "pyyaml>=5.1"
         ],
-    python_requires='>=3.9,<=3.12',
+    python_requires='>=3.9,<3.13',
     packages=setuptools.find_packages(exclude=["test_*"]),
     include_package_data=True,
     entry_points={'console_scripts': [

--- a/test_umbra/test_mailer.py
+++ b/test_umbra/test_mailer.py
@@ -8,6 +8,8 @@ import pwd
 import socket
 import os
 import re
+# smtpd has been removed as of Python 3.12; will need to use aiosmtpd instead
+# https://aiosmtpd.aio-libs.org/en/latest/migrating.html
 import smtpd
 import smtplib
 import asyncore


### PR DESCRIPTION
Previously any Python version above a minimum was allowed via setup.py, and we only tested that minimum version with CircelCI.  Now an explicit range of versions is tested and a maximum is defined in setup.py as well.  Currently that range of tested and supported Python versions is 3.9 to 3.11, inclusive.  (Python 3.12 dropped several modules we use, so it will take some work to support.)