### PR TITLE
Add pyproject.toml to project to enable PEP 517-compliant install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# https://github.com/pypa/pip/issues/6334
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This adds a stub pyproject.toml to the top level of the project, so that pip installs no longer show a deprecation warning about the "the legacy setup.py bdist_wheel mechanism."  I think this is equivalent to explicitly enabling this mode with `--use-pep517` for pip, if I understood [the issue](https://github.com/pypa/pip/issues/6334) correctly.